### PR TITLE
 Pick pre-split commits from the 'Silence compile warnings' PR

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,3 +1,7 @@
+ifeq ($(BUILD_VERBOSE),1)
+A2X_VERBOSE = -v
+endif
+
 DOCS_EN := $(patsubst %.asciidoc,%,$(wildcard *.asciidoc */*.asciidoc))
 DOCS_ES := $(patsubst %.asciidoc,%,$(wildcard *_es.asciidoc */*_es.asciidoc))
 DOCS_FR := $(patsubst %.asciidoc,%,$(wildcard *_fr.asciidoc */*_fr.asciidoc))
@@ -11,12 +15,17 @@ LARGE := $(LARGE_EN) $(LARGE_ES) $(LARGE_FR)
 
 #include $(patsubst %,%.dep,$(LARGE))
 
-A2X = ./a2x --xsltproc-opts "--stringparam toc.section.depth 3 \
-			   --stringparam toc.max.depth 2 \
-			   --stringparam generate.section.toc.level 2 \
-			   --stringparam generate.toc 'book toc,title chapter toc'" \
-	  --asciidoc-opts "-f docbook.conf" \
-	  --dblatex-opts "-P doc.publisher.show=0 -P latex.output.revhistory=0 -s ./emc2.sty"
+A2X = ./a2x \
+	--xsltproc-opts "\
+	    --stringparam toc.section.depth 3 \
+	    --stringparam toc.max.depth 2 \
+	    --stringparam generate.section.toc.level 2 \
+	    --stringparam generate.toc 'book toc,title chapter toc'" \
+	--asciidoc-opts "-f docbook.conf" \
+	--dblatex-opts "\
+	    -P doc.publisher.show=0 \
+	    -P latex.output.revhistory=0 -s ./emc2.sty" \
+	$(A2X_VERBOSE)
 
 all:
 	$(MAKE) -C ../../src docs
@@ -57,15 +66,15 @@ xref_en.links: $(patsubst %,%.db,$(SMALL))
 #	asciidoc -a stylesheet=$(shell pwd)/linuxcnc.css -f xhtml11.conf -d book -a toc -a numbered -b xhtml11 $< || (X=$$?; rm $@; exit $$X)
 
 %.pdf: %.asciidoc
-	$(A2X) -L -d book -vf pdf $< || (X=$$?; rm $@; exit $$X)
+	$(A2X) -L -d book -f pdf $< || (X=$$?; rm $@; exit $$X)
 
 $(patsubst %,%.html,$(LARGE)) :: %.html: %.asciidoc
-	$(A2X) --stylesheet=./linuxcnc.css -L -d book -vf xhtml $< || (X=$$?; rm $@; exit $$X)
+	$(A2X) --stylesheet=./linuxcnc.css -L -d book -f xhtml $< || (X=$$?; rm $@; exit $$X)
 
 #$(patsubst %,%.html,$(LARGE_ES)) :: %.html: %.asciidoc
-#	$(A2X) --stylesheet=../linuxcnc.css -L -d book -vf xhtml $< || (X=$$?; rm $@; exit $$X)
+#	$(A2X) --stylesheet=../linuxcnc.css -L -d book -f xhtml $< || (X=$$?; rm $@; exit $$X)
 
 #$(patsubst %,%.html,$(LARGE_FR)) :: %.html: %.asciidoc
-#	$(A2X) --stylesheet=../linuxcnc.css -L -d book -vf xhtml $< || (X=$$?; rm $@; exit $$X)
+#	$(A2X) --stylesheet=../linuxcnc.css -L -d book -f xhtml $< || (X=$$?; rm $@; exit $$X)
 
 .PHONY: all docs htmldocs pdfdocs docclean clean

--- a/src/Submakefile
+++ b/src/Submakefile
@@ -1,3 +1,7 @@
+ifeq ($(BUILD_VERBOSE),1)
+A2X_VERBOSE = -v
+endif
+
 .PHONY: docs docsclean checkref checkref_en checkref_es checkref_fr
 .PHONY: pdfdocs htmldocs install-doc install-doc-pdf install-doc-html
 
@@ -345,15 +349,24 @@ HTML_TARGETS := \
 	$(DOC_DIR)/html/index_es.html \
 	$(DOC_DIR)/html/index_fr.html \
 
-A2X = a2x --xsltproc-opts "--stringparam toc.section.depth 3 \
-			   --stringparam toc.max.depth 2 \
-			   --stringparam generate.section.toc.level 2 \
-			   --stringparam generate.toc 'book toc,title chapter toc'" \
-	  -a "scriptdir=$(DOC_SRCDIR)/" \
-	  --asciidoc-opts "-f $(DOC_SRCDIR)/docbook.conf -f $(DOC_SRCDIR)/asciidoc-dont-replace-arrows.conf" \
-	  --dblatex-opts "-P doc.publisher.show=0 -P latex.output.revhistory=0 -s $(DOC_SRCDIR)/emc2.sty \
-			  -P latex.hyperparam=colorlinks,linkcolor=blue,filecolor=blue,urlcolor=blue,citecolor=blue \
-                          $(A2X_LATEX_ENCODING)"
+A2X = a2x \
+	--xsltproc-opts "\
+	    --stringparam toc.section.depth 3 \
+	    --stringparam toc.max.depth 2 \
+	    --stringparam generate.section.toc.level 2 \
+	    --stringparam generate.toc 'book toc,title chapter toc'" \
+	-a "scriptdir=$(DOC_SRCDIR)/" \
+	--asciidoc-opts "\
+	    -f $(DOC_SRCDIR)/docbook.conf \
+	    -f $(DOC_SRCDIR)/asciidoc-dont-replace-arrows.conf" \
+	--dblatex-opts "\
+	    -P doc.publisher.show=0 \
+	    -P latex.output.revhistory=0 \
+	    -s $(DOC_SRCDIR)/emc2.sty \
+	    -P latex.hyperparam=colorlinks,linkcolor=blue,filecolor=blue,urlcolor=blue,citecolor=blue \
+            $(A2X_LATEX_ENCODING)" \
+	$(A2X_VERBOSE)
+
 
 ifeq ($(TRIVIAL_BUILD),no)
 -include $(patsubst %.asciidoc, depends/%.d, $(DOC_SRCS_TXT))
@@ -476,7 +489,7 @@ $(DOC_DIR)/html/index.html: $(DOC_SRCDIR)/index.tmpl objects/index.incl $(DOC_SR
 $(DOC_SRCDIR)/%.pdf: $(DOC_SRCDIR)/%.asciidoc
 	$(ECHO) Building $@
 	@rm -f $@
-	$(A2X) -L -d book -vf pdf $< || (X=$$?; rm $@; exit $$X)
+	$(A2X) -L -d book -f pdf $< || (X=$$?; rm $@; exit $$X)
 	@test -f $@
 
 depends/%.d: $(DOC_SRCDIR)/%.asciidoc $(DOC_SRCDIR)/asciideps

--- a/src/Submakefile
+++ b/src/Submakefile
@@ -658,8 +658,7 @@ docclean:
 	-rm -f $(DOC_TARGETS_HTML) $(DOC_DIR)/html/xref*.html $(DOC_DIR)/html/index*.html $(DOC_DIR)/*.png $(DOC_DIR)/man/*.png
 	-rm -f .htmldoc-stamp
 	-rm -f .html-images-stamp
-# unsure how to do this as Submakefile: -mah
-	-(cd $(LOC_HL_DIR); make clean)
+	+$(MAKE) -C $(LOC_HL_DIR) clean
 
 
 ifeq ($(BUILD_DOCS),yes)

--- a/src/Submakefile
+++ b/src/Submakefile
@@ -25,7 +25,7 @@ ifneq ($(MANDB),)
 default: $(DOC_DIR)/man/index.db
 $(DOC_DIR)/man/index.db: $(MAN_SRCS)
 	@echo "Updating 'whatis' database"
-	$(Q)$(MANDB) $(DOC_DIR)/man
+	$(Q)env -u MANPATH $(MANDB) $(DOC_DIR)/man
 endif
 
 ifeq ($(BUILD_DOCS),yes)

--- a/src/common/UnifiedBuild.asciidoc
+++ b/src/common/UnifiedBuild.asciidoc
@@ -236,12 +236,12 @@ single `./configure && make` run builds many RT options::
 	distributions.
 
 
-=== Principles of Operations
+== Principles of Operations
 
 The overall structure and cooperation of major components is a bit
 different from the past modus operandi.
 
-==== Major data structures
+=== Major data structures
 
 Before the 'unified build' work was undertaken,
 the RT build (RTAI) used a shared memory segment at the RTAPI
@@ -250,7 +250,7 @@ the HAL segment, no RTAPI shared memory segment.
 
 In contrast to the earlier approach, the shared memory segments in use in the 'unified build' branch are:
 
-===== The Global Data Segment
+==== The Global Data Segment
 
 This is a per-instance shared memory segment which is assumed to
 exist before any RT operations start (either flavor). It carries
@@ -273,7 +273,7 @@ the options are too diverse and heuristic in detection to relegate
 decisions of per-instance nature to autodetection mechanisms at lower
 levels.
 
-===== The HAL Data  Segment
+==== The HAL Data  Segment
 
 Besides small changes in per-object (thread, component, pin etc)
 structures there are no major changes except provisions for a
@@ -281,7 +281,7 @@ configurable segment size, plus data structures and macros/functions
 to access foreign instance HAL data segments. This is not used
 extensively in the current branch.
 
-===== The RTAPI Data  Segment
+==== The RTAPI Data  Segment
 
 The RTAPI data segment is essentially unchanged in layout respective
 to previous versions.
@@ -291,7 +291,7 @@ a shared memory segment for RTAPI data as it is all local variables in
 the rtapi_app process. In retrospect this lack of uniformity was a
 mistake, although not a showstopper.
 
-==== Relation of the major data structures
+=== Relation of the major data structures
 
 The obvious candidates for the global segment is the logging ringbuffer,
 plus key parameters driving overall instance parameters. As it is
@@ -309,7 +309,7 @@ been made for this at the per-flavor configuration information (follow
 the logic of  FLAVOR_RTAPI_DATA_IN_SHM usage to see how).
 
 
-==== Multiple instances and the role of the `shmdrv` shared memory driver
+=== Multiple instances and the role of the `shmdrv` shared memory driver
 
 Running multiple RTAPI instances side by side will make sense
 eventually, for instance for multi-spindle setups. However, these
@@ -374,9 +374,9 @@ segment by a kernel module which was previously created by a user
 process. This is a severe restriction not only for instance
 interoperability, but also for startup and shutdown.
 
-==== Major Processes
+=== Major Processes
 
-===== The rtapi_msgd Process
+==== The rtapi_msgd Process
 
 The primary purpose of the rtapi_msgd process is to create, populate
 and service the per-instance global_data_t shared memory segment. In
@@ -402,7 +402,7 @@ The rtapi_msgd changes its argv to `msgd:<instance number>` once started
 successfully to aid duplicate startup attempt detection, and instance
 shutdown.
 
-===== The rtapi_app Process (Userland threads)
+==== The rtapi_app Process (Userland threads)
 
 This is based largely on the sim_rtapi_app process used in the
 'simulator environment' in previous releases. It is present only in
@@ -428,7 +428,7 @@ scripts/realtime and the halcmd code in hal/utils how to do that.
 The rtapi_app program changes its argv to `rtapi:<instance number>` once started
 successfully.
 
-==== Kernel threads
+=== Kernel threads
 
 With RTAI and Xenomai-kernel flavors, there is no corresponding
 rtapi_app process since HAL modules are just kernel modules. There is
@@ -436,7 +436,7 @@ no conceptual change here - modules are inserted by the setuid
 module_helper.
 
 
-=== Tested Operating Systems
+== Tested Operating Systems
 
 rtai 2.6.32-122-rtai::
      as used in the 10.04LTS live CD


### PR DESCRIPTION
machinekit/machinekit#327, which silences compile warnings, fixed
several warnings in the `/docs` directory. Documentation was split
into the 'machinekit-docs' repo before the PR was merged.

These are the changes that would have followed the documentation side
of the split.

Fixes #8.