### PR TITLE
setting-up documentation of a linear delta type machine

### DIFF
--- a/machinekit-documentation/documentation-matrix.asciidoc
+++ b/machinekit-documentation/documentation-matrix.asciidoc
@@ -37,7 +37,7 @@
 |
 |
 |
-|
+| link:setting-up/setting-up-examples.asciidoc[Example machines]
 |
 |
 

--- a/machinekit-documentation/setting-up/lineardelta-FDM-printer.asciidoc
+++ b/machinekit-documentation/setting-up/lineardelta-FDM-printer.asciidoc
@@ -14,6 +14,9 @@ calibrating an extruder, temperature PID loops or working with a GUI will have a
 place in a separate document. Preferrably linked to at the end of this one and
 in the link:setting-up-example.asciidoc[setting-up page summary].
 
+If this type of machine does not act as a FDM machine, but as a mill for example
+then this document also acts as a setup guide. Most information is equivalent.
+
 Whether you use some scripts or levelling feature later on to make re-calibrating
 of endstops and/or delta radius easier / less time consuming, I would advice you
 to at least do a full setup and configuration manually to understand what happens
@@ -71,7 +74,10 @@ The thing that drives the filament into the Hot End
 
 ===== Hot End
 The shaft that melts the filament. The hot end is mounted below the effector and
-the nozzle should be the lowest point
+the nozzle should be the lowest point.
+
+If your machine has a drill bit or functions as a mill then this drill or mill bit
+also is the lowest point beneath the effector.
 
 
 == [[frame]]The Frame

--- a/machinekit-documentation/setting-up/lineardelta-FDM-printer.asciidoc
+++ b/machinekit-documentation/setting-up/lineardelta-FDM-printer.asciidoc
@@ -346,8 +346,34 @@ the moment the homing sequence is done.
 
 
 == [[delta-radius]]Delta Radius
+If the `delta radius` is not correct, the movement of the effector will be convex
+or concave instead of straight.
+
+We use the same way we calibrated the endstops in the previous section for
+finetuning the `delta radius`.
 
 === Setting `Delta Radius` value from terminal
+
+. go to `TOWER C` and find the  Z-value like in steps 3 & 4 of <<endstops,section 5.1>>
+. like in steps 5 and following move the effector down, but this time at (0,0) so the
+effector will be above the center.
+. in small steps change the `delta radius` {value} until the Z-position matches
+like in step 6, only this time from the terminal:
++
+[source]
+----
+halcmd sets lineardeltakins.R {value}
+----
+. This value now will be changed, and is not effected by homing.
+. **change the value in your ini file!**
+
+---
+
+= Done!
+Your movement should run straight above the bed. It is highly recommended to use
+a dial caliper because it just makes life easy. If you don't have access to one
+you can get the same results with the "scraping-paper-method". Don't worry
+about that.
 
 
 [WARNING]

--- a/machinekit-documentation/setting-up/lineardelta-FDM-printer.asciidoc
+++ b/machinekit-documentation/setting-up/lineardelta-FDM-printer.asciidoc
@@ -1,0 +1,159 @@
+[cols="3*"]
+|===
+|link:setting-up-examples.asciidoc[Setting up examples]
+|link:../documents-index.asciidoc[Back to the main Documents index]
+|link:../documentation-matrix.asciidoc[Documentation matrix]
+|===
+
+Linear Delta FDM printer setup
+==============================
+
+This guide is meant as a start for setting up the machine in a way that will enable
+you to get a machine running. Other instructions of guides, which focus on
+calibrating an extruder, temperature PID loops or working with a GUI will have a better
+place in a separate document. Preferrably linked to at the end of this one and
+in the link:setting-up-example.asciidoc[setting-up page summary].
+
+Whether you use some scripts or levelling feature later on to make re-calibrating
+of endstops and/or delta radius easier / less time consuming, I would advice you
+to at least do a full setup and configuration manually to understand what happens
+exactly.
+
+Contents
+========
+
+. <<doctionary,Dictionary>>
+. <<frame,The Frame>>
+. <<connecting,Connecting>>
+. <<configuration,Configuration Files>>
+. <<endstops,Endstops>>
+. <<delta-radius,Delta Radius>>
+
+---
+
+
+== [[dictionary]]Dictionary
+
+These instructions will talk about towers, axes, joints, motors and connectors and other
+parts of the machine. Below you'll find a short summary of meaningful names.
+
+===== Axes
+The axes which are mentionned are the cartesian `X`, `Y` and `Z` axis who together
+describe a coordinate in caresian space by (`X`,`Y`,`Z`).
+
+===== Tower
+The vertical actuator on which the carriage runs. To eliminate confusion between
+motors, joints, axes, cartesian space, connectors etc. these 3 towers are called
+`TOWER A`, `TOWER B` and `TOWER C`.
+
+Go sit before your machine and see that they are located (maybe put a yellow
+sticky note on the tower afterwards):
+
+- `TOWER A`: front left, location (-X,-Y)
+- `TOWER B`: front right, location (+X,-Y)
+- `TOWER C`: back middle, location (0,+Y)
+
+===== Carriage
+This vertical moving platform connects a set of rods to a tower. It is moved by
+something like a spindle or a timing belt.
+
+===== Effector
+The moving platform which is connected to towers by 3 sets of rods.
+
+===== Paralellogram
+The 2 rods from each carriage together with a side of the effector form a
+paralellogram. The 3 paralellograms together constrain the machine in such a way
+that the effector cannot rotate around the `x`, `y` and `z` axes (pitch `a`,
+roll `b` and yaw `c`) degrees of dreedom
+
+===== Extruder
+The thing that drives the filament into the Hot End
+
+===== Hot End
+The shaft that melts the filament. The hot end is mounted below the effector and
+the nozzle should be the lowest point
+
+
+== [[frame]]The Frame
+
+The frame is the base of everything. All further setup depends on the frame and
+the bed so do this as accurate as possible. If you run into a problem first fix
+it so you have a good foundation.
+
+==== Towers
+
+The first thing to do is to make sure the 3 columns are parallel and on the correct
+distances from each other. The more the position corresponds with the theoretical
+position, the better the dimensions of the printed part will be.
+
+It's also important to have the 3 columns running parallel to each other. Without
+this paralellity the part dimensions will not be uniform in height. One way to
+start would be to set the towers vertical with a level, and measure the distances
+from one to the other 2.
+
+==== The Bed
+
+The bed should be perpendicular to the 3 parallel towers. Preferrably the bed
+is constrained on 3 points near the tower so adjusting a point directly influences
+the angle of the bed at the tower you are setting up.
+
+. Put the bed on the 3 points near the towers
+. Get a carpenters angle and put this on the bed. Point 1 side upwards, parallel
+to the tower, and the other side on the bed pointing towards the middle of the
+bed.
+
++
+Preferrably, get a bright area after the gap between the angle and tower and move
+the angle towards the tower. If the gap is not fully closed over the full length
+you should use the adjusting point to get close the gap.
+
+
+== [[connecting]]Connecting
+
+Most important thing to do here is that we make a clear distinction of the naming
+of axes, joints, towers and connectors.
+
+When you use some sort of configuration (most likely a BeagleBone Black with
+a 3D printing cape) you probalbly have motor connections named on the board like
+`X`, `Y` and `Z`. I like to remember the mnemonic "CAB", like in "Taxi!".
+
+Here `CAB` uses the `XYZ` connectors. You just remember `CAB` and connect:
+
+- motor of `TOWER C` => `connector X` (which is normally `joint[0]`)
+- motor of `TOWER A` => `connector Y` (which is normally `joint[1]`)
+- motor of `TOWER B` => `connector Z` (which is normally `joint[2]`)
+
+== [[configuration]]Configuration Files
+
+=== INI-file
+
+=== HAL-file
+
+
+== [[endstops]]Endstops
+
+=== Use of debug pins in kinematics
+
+=== Setting `HOME_OFFSET`  from terminal
+
+
+== [[delta-radius]]Delta Radius
+
+=== Setting `Delta Radius` value from terminal
+
+
+[WARNING]
+====
+todo:
+
+- document and link to calibrating extrusion do not exist
+- smart scripts and possibly other tools
+- GUI and other setup instructions
+====
+
+[cols="3*"]
+|===
+|link:setting-up-examples.asciidoc[Setting up examples]
+|link:../documents-index.asciidoc[Back to the main Documents index]
+|link:../documentation-matrix.asciidoc[Documentation matrix]
+|===

--- a/machinekit-documentation/setting-up/lineardelta-FDM-printer.asciidoc
+++ b/machinekit-documentation/setting-up/lineardelta-FDM-printer.asciidoc
@@ -131,16 +131,218 @@ Here `CAB` uses the `XYZ` connectors. You just remember `CAB` and connect:
 
 == [[configuration]]Configuration Files
 
+When you start Machinekit you get to choose which configuration you want to use
+choose one with "lineardelta" or equivalent. Its not really important what the
+name is though. You can make a "my machine" configuration if you want.
+
+Scroll around the configuration (`config` directory in machinekit) directory to
+see if your hardware setup has one. If it's not there then you must make one.
+
+It's important to understand that the `INI` file is just loaded once, during
+startup. So any changes you make in your `INI` file are only loaded during
+the start.
+
+A configuration consists of an `INI` file and a `HAL` file. More info can be found
+in the legacy LinuxCNC documentation. For now below are the parts which are
+important for the machine setup.
+
 === INI-file
+
+When making a configuration file for this type of machine you should look at the
+following sections. Below examples with comments about their use.
+
+[source,ini]
+----
+[EMC]
+# below text will show in the GUI for example
+MACHINE = type the name of your machine here
+----
+
+[source,ini]
+----
+[MACHINE]
+DELTA_R = 158.55 #here the delta radius is given
+CF_ROD = 326.37  #here the rod length given
+----
+
+[source,ini]
+----
+[HAL]
+# this file will hold the settings of which
+# software pin is wired to which hardware pin
+HALFILE = the-location-of-the-hal-file.hal
+----
+
+[source,ini]
+----
+[AXIS_n] #where n is 0, 1, 2 and 3
+TYPE =              LINEAR
+
+# for our linear delta type machine we need
+# to have the value of MAX_VELOCITY way below
+# the value of STEPGEN_MAX_VEL.
+#
+# why? do you ask...
+#
+# MAX_VELOCITY of [AXIS_0] is the velocity of
+# the cartesian x-axis, where STEPGEN_MAX_VEL
+# is the max velocity of of JOINT[0].
+#
+# because of the kinematics of our machine
+# the joint must be able to move and accelerate
+# a lot quicker than the cartesian axis.
+# Especially if the effector is moving at the
+# edge of the working area (radius)
+#
+# this is confusing, I know
+MAX_VELOCITY =      250.0
+STEPGEN_MAX_VEL =   390
+
+# the same goes for the acceleration settings.
+# here again the difference between cartesian
+# and joint setting
+MAX_ACCELERATION =  1100.0
+STEPGEN_MAX_ACC =   5000
+
+# this is the scale of the motor.
+# simply make positive/negative to
+# change the direction
+SCALE =  -128
+
+# when homing the value of HOME_OFFSET is used
+# for setting the JOINT[n] position.
+# different
+HOME =              710.00
+HOME_OFFSET =       711.10
+# speed (up) when homing
+HOME_SEARCH_VEL =   30.0
+# speed down (slow) when homing
+HOME_LATCH_VEL =    -1.0
+----
+
+[NOTE]
+more info about `HOMING` can be found in link:../../src/config/ini_homing.asciidoc[]
+
+[NOTE]
+since this setup document is about calibrating the mechanics, the `INI` values
+that are needed for the extruder are better of in a separate setup document. Could
+be linked to from here if/whenever it exisists.
 
 === HAL-file
 
+The `HAL` is the Hardware Abstraction Layer. If you are not familiar with this
+then please visit the link:../../machinekit-documentation/index-HAL.asciidoc[HAL index]
+with especially the link:../../src/hal/intro.asciidoc[HAL intro] before continuing.
+The `HALFILE` in the above mentionned `INI` settings contains all the "wiring logic"
+of the machine.
+
+We'll not dig deeple here, but some lines are worth mentionning
+
+[source,hal]
+----
+# this line loads the kinematics file
+loadrt lineardeltakins
+
+# settings for delta printer. These are
+# taken from the INI file mentionned above
+setp lineardeltakins.L [MACHINE]CF_ROD
+setp lineardeltakins.R [MACHINE]DELTA_R
+----
+
+==== net signal source target
+Reading a `HAL` file can be very energy draining. Just remember the following:
+
+A `signal` is the "wire" linking `pins`, where the `source pin` is mentionned after
+the `signal` and the `target pin` is mentionned after the `source pin`
+
+Ych!.... just repeat 10 times _**NOW**_ and you'll know it the 11th time when
+you pull your hair and grind your teeth reding thru a `HAL` FILE:
+
+=> => [red]#**NET SIGNAL SOURCE TARGET**# <= <=
+
+for example:
+----
+net the-signal-from-pinA-to-pinB pinA pinB
+----
+which is the same as:
+----
+net the-signal-from-pinA-to-pinB pinA
+net the-signal-from-pinA-to-pinB pinB
+----
+
 
 == [[endstops]]Endstops
+The goal of this section is gettin the exact height of the endswitch of a joint
+with respect to the bed. This is important since the nozzle will have to travel
+in a straight line across the bed and printed layers.
+
+You have to understand that `HOMING` sets the height of the
+tower joint (`TOWER C` which is `JOINT[0]`). So when the homing routine is done
+then your machine knows the height of the carriages, and in turn calculates the
+cartesian (`X`,`Y`,`Z`) position.
+
+you can view the `JOINTS` position in the `joint mode` and the cartesian values
+in the `world mode`. you can switch between them in the GUI.
 
 === Use of debug pins in kinematics
+. home the machine
+. go to a position near a tower within the `MDI mode`. This is where you manually
+give a command to move the effector go to the tower coordinates. Like
+`G1 X0 Y150 Z50 F2000`. This should result in the effector being at the
+position of the tower at the back.
 
-=== Setting `HOME_OFFSET`  from terminal
++
+[NOTE]
+`Y150` in the example should be your delta radius value. Furthermore the rods of the
+paralellogram should be as-good-as vertical. Big deviation means you have to look
+into the reason "why". A small deviation is no problem since the cosine part (`Z`)
+of the (`X`,`Y`) error is very small and has very little influence of the height
+(position of the tower)
+
+. go down with the nozzle until you experience friction between nozzle and bed
+with the "dragging-paper-method" or to a specified height of a dial caliper.
+. **write down the cartesian Z-position**.
+. go to another tower and move down until you have the nozzle at the same height
+as `TOWER C` + 5 mm.
+. go down in little steps, and change from the terminal the joint debug pins. These
+pins move the effector lower/higher without effecting the joint[n] position or
+Z-height readout value. Do like this and replace {n} with the joint you are workin
+on:
+
++
+[source]
+----
+halcmd sets lineardeltakins.J{n}off 0.1
+----
+you should be able to notice (paper-friction-test, or see the dial caliper change)
+the effector move. Do this in little steps to prevent following errors until
+you have the same dragging-paper-friction situation at the same cartesian
+Z-position as noted with `TOWER C`.
+. **write down the final value of [red]#lineardeltakins.J{n}off# **
+. return to step 5 for the remaining tower.
+
+
+=== Setting `HOME_OFFSET` values
+Now that we know the errors of our endswitches, we can either correct them in
+our `INI` file (which will require a restart for them to be loaded)
+
+or...
+
+. we can without having to restart
+change the value from terminal like this, where {n} is to be replaced by
+the joint number of the HOME_OFFSET you want to change, and {value} is the new
+value you found in the previous steps:
++
+[source]
+----
+halcmd sets axis.{n}.home_offset {value}
+----
+. After you have done this for all the offsets you want to change you need to home
+the machine again, which will result in the joints getting an other position
+the moment the homing sequence is done.
+. Set all the debug pins `lineardeltakins.J{n}off` to zero.
+. Re-home for good measure.
+. **CHANGE THESE VALUES IN YOUR INI FILE!**
 
 
 == [[delta-radius]]Delta Radius

--- a/machinekit-documentation/setting-up/lineardelta-FDM-printer.asciidoc
+++ b/machinekit-documentation/setting-up/lineardelta-FDM-printer.asciidoc
@@ -25,7 +25,7 @@ exactly.
 Contents
 ========
 
-. <<doctionary,Dictionary>>
+. <<dictionary,Dictionary>>
 . <<frame,The Frame>>
 . <<connecting,Connecting>>
 . <<configuration,Configuration Files>>
@@ -41,7 +41,7 @@ These instructions will talk about towers, axes, joints, motors and connectors a
 parts of the machine. Below you'll find a short summary of meaningful names.
 
 ===== Axes
-The axes which are mentionned are the cartesian `X`, `Y` and `Z` axis who together
+The axes which are mentioned are the cartesian `X`, `Y` and `Z` axis who together
 describe a coordinate in caresian space by (`X`,`Y`,`Z`).
 
 ===== Tower
@@ -66,8 +66,8 @@ The moving platform which is connected to towers by 3 sets of rods.
 ===== Paralellogram
 The 2 rods from each carriage together with a side of the effector form a
 paralellogram. The 3 paralellograms together constrain the machine in such a way
-that the effector cannot rotate around the `x`, `y` and `z` axes (pitch `a`,
-roll `b` and yaw `c`) degrees of dreedom
+that the effector cannot rotate around the `x`, `y` and `z` axes (roll `a`,
+pitch `b` and yaw `c`) degrees of dreedom
 
 ===== Extruder
 The thing that drives the filament into the Hot End
@@ -105,8 +105,8 @@ the angle of the bed at the tower you are setting up.
 
 . Put the bed on the 3 points near the towers
 . Get a carpenters angle and put this on the bed. Point 1 side upwards, parallel
-to the tower, and the other side on the bed pointing towards the middle of the
-bed.
+  to the tower, and the other side on the bed pointing towards the middle of the
+  bed.
 
 +
 Preferrably, get a bright area after the gap between the angle and tower and move
@@ -272,7 +272,7 @@ net the-signal-from-pinA-to-pinB pinB
 
 
 == [[endstops]]Endstops
-The goal of this section is gettin the exact height of the endswitch of a joint
+The goal of this section is getting the exact height of the endswitch of a joint
 with respect to the bed. This is important since the nozzle will have to travel
 in a straight line across the bed and printed layers.
 
@@ -287,9 +287,9 @@ in the `world mode`. you can switch between them in the GUI.
 === Use of debug pins in kinematics
 . home the machine
 . go to a position near a tower within the `MDI mode`. This is where you manually
-give a command to move the effector go to the tower coordinates. Like
-`G1 X0 Y150 Z50 F2000`. This should result in the effector being at the
-position of the tower at the back.
+  give a command to move the effector go to the tower coordinates. Like
+  `G1 X0 Y150 Z50 F2000`. This should result in the effector being at the
+  position of the tower at the back.
 
 +
 [NOTE]
@@ -300,20 +300,21 @@ of the (`X`,`Y`) error is very small and has very little influence of the height
 (position of the tower)
 
 . go down with the nozzle until you experience friction between nozzle and bed
-with the "dragging-paper-method" or to a specified height of a dial caliper.
+  with the "dragging-paper-method" or to a specified height of a dial caliper.
 . **write down the cartesian Z-position**.
 . go to another tower and move down until you have the nozzle at the same height
-as `TOWER C` + 5 mm.
+  as `TOWER C` + 5 mm.
 . go down in little steps, and change from the terminal the joint debug pins. These
-pins move the effector lower/higher without effecting the joint[n] position or
-Z-height readout value. Do like this and replace {n} with the joint you are workin
-on:
+  pins move the effector lower/higher without effecting the joint[n] position or
+  Z-height readout value. Do like this and replace {n} with the joint you are workin
+  on:
 
 +
 [source]
 ----
 halcmd sets lineardeltakins.J{n}off 0.1
 ----
++
 you should be able to notice (paper-friction-test, or see the dial caliper change)
 the effector move. Do this in little steps to prevent following errors until
 you have the same dragging-paper-friction situation at the same cartesian
@@ -329,17 +330,17 @@ our `INI` file (which will require a restart for them to be loaded)
 or...
 
 . we can without having to restart
-change the value from terminal like this, where {n} is to be replaced by
-the joint number of the HOME_OFFSET you want to change, and {value} is the new
-value you found in the previous steps:
+  change the value from terminal like this, where {n} is to be replaced by
+  the joint number of the HOME_OFFSET you want to change, and {value} is the new
+  value you found in the previous steps:
 +
 [source]
 ----
 halcmd sets axis.{n}.home_offset {value}
 ----
 . After you have done this for all the offsets you want to change you need to home
-the machine again, which will result in the joints getting an other position
-the moment the homing sequence is done.
+  the machine again, which will result in the joints getting an other position
+  the moment the homing sequence is done.
 . Set all the debug pins `lineardeltakins.J{n}off` to zero.
 . Re-home for good measure.
 . **CHANGE THESE VALUES IN YOUR INI FILE!**
@@ -356,14 +357,18 @@ finetuning the `delta radius`.
 
 . go to `TOWER C` and find the  Z-value like in steps 3 & 4 of <<endstops,section 5.1>>
 . like in steps 5 and following move the effector down, but this time at (0,0) so the
-effector will be above the center.
+  effector will be above the center.
 . in small steps change the `delta radius` {value} until the Z-position matches
-like in step 6, only this time from the terminal:
+  like in step 6, only this time from the terminal:
 +
 [source]
 ----
 halcmd sets lineardeltakins.R {value}
 ----
+. Decrease this value if the effector is too low (too little play between hot end
+  and bed). Decreasing raises the effector.
+. Increase this value if there is too much space between nozzle and bed.
+  increasing means lowering the effector.
 . This value now will be changed, and is not effected by homing.
 . **change the value in your ini file!**
 

--- a/machinekit-documentation/setting-up/setting-up-examples.asciidoc
+++ b/machinekit-documentation/setting-up/setting-up-examples.asciidoc
@@ -15,6 +15,9 @@ with different hardware.
 
 . link:lineardelta-FDM-printer.asciidoc[Linear Delta FDM printer]
 
++
+Starting point also for other machines which use the lineardelta kinematics
+
 
 [cols="3*"]
 |===

--- a/machinekit-documentation/setting-up/setting-up-examples.asciidoc
+++ b/machinekit-documentation/setting-up/setting-up-examples.asciidoc
@@ -1,0 +1,24 @@
+[cols="3*"]
+|===
+|
+|link:../documents-index.asciidoc[Back to the main Documents index]
+|link:../documentation-matrix.asciidoc[Documentation matrix]
+|===
+
+Setting up a machine:
+=====================
+
+Below you'll find links to examples of the steps to take to get your
+machine moving. This will be examples where in some cases hardware specific
+steps are mentioned. But it should be generic enough to set up a machine
+with different hardware.
+
+. link:lineardelta-FDM-printer.asciidoc[Linear Delta FDM printer]
+
+
+[cols="3*"]
+|===
+|
+|link:../documents-index.asciidoc[Back to the main Documents index]
+|link:../documentation-matrix.asciidoc[Documentation matrix]
+|===


### PR DESCRIPTION
Set-up instructions focussing on calibrating the mechanics of a linear delta type machine. In the same time getting a new user thru some steps (terminal) and concepts (HAL) with links to other parts of the documentation.

Special care was taken not to focus on platform or 3D FDM/FFF printing alone. This can be done in other possibly future documents.