### PR TITLE
Script for man page conversion to asciidoc

### DIFF
--- a/machinekit-documentation/components/abs.asciidoc
+++ b/machinekit-documentation/components/abs.asciidoc
@@ -1,0 +1,85 @@
+ABS(9) HAL Component ABS(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+----------------------------------------------------------------
+   abs - Compute the absolute value and sign of the input signal
+----------------------------------------------------------------
+
+SYNOPSIS
+
+------
+   abs
+------
+
+USAGE SYNOPSIS
+
+-----------------------------------------------------------------------------------------
+   loadrt abs
+
+   newinst abs <newinstname> [ pincount=N | iprefix=prefix ] [instanceparamX=X | argX=X ]
+-----------------------------------------------------------------------------------------
+
+FUNCTIONS
+
+-----------------------------------------------------------------------
+   abs.N.funct
+          ( OR <newinstname>.funct (requires a floating-point thread) )
+-----------------------------------------------------------------------
+
+PINS
+
+-------------------------------------------------------------
+   abs.N.in  float in
+          ( OR <newinstname>.in  float in  )
+
+
+   Analog input value
+
+   abs.N.out  float out
+          ( OR <newinstname>.out  float out  )
+
+
+   Analog output value, always positive
+
+   abs.N.sign  bit out
+          ( OR <newinstname>.sign  bit out  )
+
+
+   Sign of input, false for positive, true for negative
+
+   abs.N.is_positive  bit out
+          ( OR <newinstname>.is_positive  bit out  )
+
+
+   true if input is positive, false if input is 0 or negative
+
+   abs.N.is_negative  bit out
+          ( OR <newinstname>.is_negative  bit out  )
+
+
+   true if input is negative, false if input is 0 or positive
+-------------------------------------------------------------
+
+LICENSE
+
+------
+   GPL
+------
+
+Machinekit Documentation 2015-11-01 ABS(9)

--- a/machinekit-documentation/components/abs_s32.asciidoc
+++ b/machinekit-documentation/components/abs_s32.asciidoc
@@ -1,0 +1,85 @@
+ABS_S32(9) HAL Component ABS_S32(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+--------------------------------------------------------------------
+   abs_s32 - Compute the absolute value and sign of the input signal
+--------------------------------------------------------------------
+
+SYNOPSIS
+
+----------
+   abs_s32
+----------
+
+USAGE SYNOPSIS
+
+---------------------------------------------------------------------------------------------
+   loadrt abs_s32
+
+   newinst abs_s32 <newinstname> [ pincount=N | iprefix=prefix ] [instanceparamX=X | argX=X ]
+---------------------------------------------------------------------------------------------
+
+FUNCTIONS
+
+-------------------------------------
+   abs_s32.N.funct
+          ( OR <newinstname>.funct  )
+-------------------------------------
+
+PINS
+
+-------------------------------------------------------------
+   abs_s32.N.in  s32 in
+          ( OR <newinstname>.in  s32 in  )
+
+
+   input value
+
+   abs_s32.N.out  s32 out
+          ( OR <newinstname>.out  s32 out  )
+
+
+   output value, always non-negative
+
+   abs_s32.N.sign  bit out
+          ( OR <newinstname>.sign  bit out  )
+
+
+   Sign of input, false for positive, true for negative
+
+   abs_s32.N.is_positive  bit out
+          ( OR <newinstname>.is_positive  bit out  )
+
+
+   true if input is positive, false if input is 0 or negative
+
+   abs_s32.N.is_negative  bit out
+          ( OR <newinstname>.is_negative  bit out  )
+
+
+   true if input is negative, false if input is 0 or positive
+-------------------------------------------------------------
+
+LICENSE
+
+------
+   GPL
+------
+
+Machinekit Documentation 2015-11-01 ABS_S32(9)

--- a/machinekit-documentation/components/and2.asciidoc
+++ b/machinekit-documentation/components/and2.asciidoc
@@ -1,0 +1,75 @@
+AND2(9) HAL Component AND2(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+----------------------------
+   and2 - Two-input AND gate
+----------------------------
+
+SYNOPSIS
+
+-------
+   and2
+-------
+
+USAGE SYNOPSIS
+
+------------------------------------------------------------------------------------------
+   loadrt and2
+
+   newinst and2 <newinstname> [ pincount=N | iprefix=prefix ] [instanceparamX=X | argX=X ]
+------------------------------------------------------------------------------------------
+
+FUNCTIONS
+
+-------------------------------------
+   and2.N.funct
+          ( OR <newinstname>.funct  )
+-------------------------------------
+
+PINS
+
+---------------------------------------------------------------------------------
+   and2.N.in0  bit in
+          ( OR <newinstname>.in0  bit in  )
+
+
+   and2.N.in1  bit in
+          ( OR <newinstname>.in1  bit in  )
+
+
+   and2.N.out  bit out
+          ( OR <newinstname>.out  bit out  )
+
+
+   out is computed from the value of in0 and in1 according to the following rule:
+
+          in0=TRUE in1=TRUE
+                 out=TRUE
+
+          Otherwise,
+                 out=FALSE
+---------------------------------------------------------------------------------
+
+LICENSE
+
+------
+   GPL
+------
+
+Machinekit Documentation 2015-11-01 AND2(9)

--- a/machinekit-documentation/components/andn.asciidoc
+++ b/machinekit-documentation/components/andn.asciidoc
@@ -1,0 +1,80 @@
+ANDN(9) HAL Component ANDN(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+--------------------------
+   andn - N input AND gate
+--------------------------
+
+SYNOPSIS
+
+-------
+   andn
+-------
+
+USAGE SYNOPSIS
+
+------------------------------------------------------------------------------------------
+   loadrt andn
+
+   newinst andn <newinstname> [ pincount=N | iprefix=prefix ] [instanceparamX=X | argX=X ]
+------------------------------------------------------------------------------------------
+
+DESCRIPTION
+
+---------------------------------------------------------------------------
+    out is computed from the result of logic AND applied to all input pins.
+---------------------------------------------------------------------------
+
+FUNCTIONS
+
+-------------------------------------
+   andn.N.funct
+          ( OR <newinstname>.funct  )
+-------------------------------------
+
+PINS
+
+------------------------------------------------------------
+   andn.N.in#.  bit in (M=0..pincount)
+          ( OR <newinstname>.in#.  bit in (M=0..pincount)  )
+
+
+   andn.N.out  bit out
+          ( OR <newinstname>.out  bit out  )
+------------------------------------------------------------
+
+INST_PARAMETERS
+
+----------------------------
+   pincount int (default: 2)
+----------------------------
+
+AUTHOR
+
+---------------------
+   Alexander Roessler
+---------------------
+
+LICENSE
+
+------
+   GPL
+------
+
+Machinekit Documentation 2015-11-01 ANDN(9)

--- a/machinekit-documentation/components/at_pid.asciidoc
+++ b/machinekit-documentation/components/at_pid.asciidoc
@@ -1,0 +1,316 @@
+AT_PID(9) HAL Component AT_PID(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+-------------------------------------------------------------------------------------------------------------------------
+   at_pid - HAL component that provides Proportional     Integeral/Derivative control loops.  It is a realtime component.
+-------------------------------------------------------------------------------------------------------------------------
+
+SYNOPSIS
+
+---------
+   at_pid
+---------
+
+USAGE SYNOPSIS
+
+--------------------------------------------------------------------------------------------
+   loadrt at_pid
+
+   newinst at_pid <newinstname> [ pincount=N | iprefix=prefix ] [instanceparamX=X | argX=X ]
+--------------------------------------------------------------------------------------------
+
+DESCRIPTION
+
+--------------------------------------------------------------------------------------
+             This file, 'at_pid.icomp', is a HAL component that provides Proportional/
+            Integeral/Derivative control loops.  It is a realtime component.
+
+            In this documentation, it is assumed that we are discussing position
+            loops.  However this component can be used to implement other loops
+            such as speed loops, torch height control, and others.
+
+            The three most important pins are 'command', 'feedback', and
+            'output'.  For a position loop, 'command' and 'feedback' are
+            in position units.  For a linear axis, this could be inches,
+            mm, metres, or whatever is relavent.  Likewise, for a angular
+            axis, it could be degrees, radians, etc.  The units of the
+            'output' pin represent the change needed to make the feedback
+            match the command.  As such, for a position loop 'Output' is
+            a velocity, in inches/sec, mm/sec, degrees/sec, etc.
+
+            Each loop has several other pins as well.  'error' is equal to
+            'command' minus 'feedback'.  'enable' is a bit that enables
+            the loop.  If 'enable' is false, all integrators are reset,
+            and the output is forced to zero.  If 'enable' is true, the
+            loop operates normally.
+
+            The PID gains, limits, and other 'tunable' features of the
+            loop are implemented as parameters.  These are as follows:
+
+            Pgain        Proportional gain
+            Igain        Integral gain
+            Dgain        Derivative gain
+            bias         Constant offset on output
+            FF0          Zeroth order Feedforward gain
+            FF1          First order Feedforward gain
+            FF2          Second order Feedforward gain
+            deadband     Amount of error that will be ignored
+            maxerror     Limit on error
+            maxerrorI    Limit on error integrator
+            maxerrorD    Limit on error differentiator
+            maxcmdD      Limit on command differentiator
+            maxcmdDD     Limit on command 2nd derivative
+            maxoutput    Limit on output value
+
+            All of the limits (max____) are implemented such that if the
+            parameter value is zero, there is no limit.
+
+            A number of internal values which may be usefull for testing
+            and tuning are also available as parameters.  To avoid cluttering
+            the parameter list, these are only exported if "debug=1" is
+            specified on the insmod command line.
+
+            errorI       Integral of error
+            errorD       Derivative of error
+            cmdD     Derivative of the command
+            cmdDd    2nd derivative of the command
+
+            The PID loop calculations are as follows (see the code for
+            all the nitty gritty details):
+
+            error = command - feedback
+            if ( fabs(error) < deadband ) then error = 0
+            limit error to +/- maxerror
+            errorI += error * period
+            limit errorI to +/- maxerrorI
+            errorD = (error - previouserror) / period
+            limit errorD to +/- paxerrorD
+            cmdD = (command - previouscommand) / period
+            limit cmdD to +/- maxcmdD
+            cmdDd = (cmdD - previouscmdD) / period
+            limit cmdDd to +/- maxcmdDD
+            output = bias + error * Pgain + errorI * Igain +
+                     errorD * Dgain + command * FF0 + cmdD * FF1 +
+                     cmdDd * FF2
+            limit output to +/- maxoutput
+
+            This component exports one function called '<name>.do-pid-calcs'
+--------------------------------------------------------------------------------------
+
+FUNCTIONS
+
+------------------------------------------------------------------------------------
+   at_pid.N.do_pid_calcs.funct
+          ( OR <newinstname>.do_pid_calcs.funct (requires a floating-point thread) )
+------------------------------------------------------------------------------------
+
+PINS
+
+------------------------------------------------------------------------------------------------------------------
+   at_pid.N.deadband  float in (default: 0.0)
+          ( OR <newinstname>.deadband  float in (default: 0.0) )
+
+
+   Amount of error that will be ignored
+
+   at_pid.N.maxerror  float in (default: 0.0)
+          ( OR <newinstname>.maxerror  float in (default: 0.0) )
+
+
+   Limit on error
+
+   at_pid.N.maxerrorI  float in (default: 0.0)
+          ( OR <newinstname>.maxerrorI  float in (default: 0.0) )
+
+
+   Limit on error integrator
+
+   at_pid.N.maxerrorD  float in (default: 0.0)
+          ( OR <newinstname>.maxerrorD  float in (default: 0.0) )
+
+
+   Limit on error differentiator
+
+   at_pid.N.maxcmdD  float in (default: 0.0)
+          ( OR <newinstname>.maxcmdD  float in (default: 0.0) )
+
+
+   Limit on command differentiator
+
+   at_pid.N.maxcmdDD  float in (default: 0.0)
+          ( OR <newinstname>.maxcmdDD  float in (default: 0.0) )
+
+
+   Limit on command 2nd derivative
+
+   at_pid.N.bias  float io (default: 0.0)
+          ( OR <newinstname>.bias  float io (default: 0.0) )
+
+
+   Constant offset on output
+
+   at_pid.N.Pgain  float io (default: 1.0)
+          ( OR <newinstname>.Pgain  float io (default: 1.0) )
+
+
+   Proportional gain
+
+   at_pid.N.Igain  float io (default: 0.0)
+          ( OR <newinstname>.Igain  float io (default: 0.0) )
+
+
+   Integral gain
+
+   at_pid.N.Dgain  float io (default: 0.0)
+          ( OR <newinstname>.Dgain  float io (default: 0.0) )
+
+
+   Derivative gain
+
+   at_pid.N.FF0  float io (default: 0.0)
+          ( OR <newinstname>.FF0  float io (default: 0.0) )
+
+
+   Zeroth order Feedfoioard gain
+
+   at_pid.N.FF1  float io (default: 0.0)
+          ( OR <newinstname>.FF1  float io (default: 0.0) )
+
+
+   First order Feedforward gain
+
+   at_pid.N.FF2  float io (default: 0.0)
+          ( OR <newinstname>.FF2  float io (default: 0.0) )
+
+
+   Second order Feedforward gain
+
+   at_pid.N.maxoutput  float io (default: 0.0)
+          ( OR <newinstname>.maxoutput  float io (default: 0.0) )
+
+
+   Limit on output value
+
+   at_pid.N.tuneEffort  float io (default: 0.5)
+          ( OR <newinstname>.tuneEffort  float io (default: 0.5) )
+
+
+
+           Control effort for limit cycle.
+
+   at_pid.N.tuneCycles  u32 io (default: 50)
+          ( OR <newinstname>.tuneCycles  u32 io (default: 50) )
+
+
+   at_pid.N.tuneType  u32 io (default: 0)
+          ( OR <newinstname>.tuneType  u32 io (default: 0) )
+
+
+   at_pid.N.errorI  float out
+          ( OR <newinstname>.errorI  float out  )
+
+
+   Integral of error
+
+   at_pid.N.errorD  float out
+          ( OR <newinstname>.errorD  float out  )
+
+
+   Derivative of error
+
+   at_pid.N.commandD  float out
+          ( OR <newinstname>.commandD  float out  )
+
+
+   Derivative of the command
+
+   at_pid.N.commandDD  float out
+          ( OR <newinstname>.commandDD  float out  )
+
+
+   2nd derivative of the command
+
+   at_pid.N.ultimateGain  float out
+          ( OR <newinstname>.ultimateGain  float out  )
+
+
+   Calc by auto-tune from limit cycle.
+
+   at_pid.N.ultimatePeriod  float io
+          ( OR <newinstname>.ultimatePeriod  float io  )
+
+
+   Calc by auto-tune from limit cycle.
+
+   at_pid.N.enable  bit in (default: 0)
+          ( OR <newinstname>.enable  bit in (default: 0) )
+
+
+   Enable/disabled the PID loop
+
+   at_pid.N.command  float in (default: 0.0)
+          ( OR <newinstname>.command  float in (default: 0.0) )
+
+
+   Commanded value
+
+   at_pid.N.feedback  float in (default: 0.0)
+          ( OR <newinstname>.feedback  float in (default: 0.0) )
+
+
+   Feedback input
+
+   at_pid.N.error  float out
+          ( OR <newinstname>.error  float out  )
+
+
+   Current error
+
+   at_pid.N.output  float out
+          ( OR <newinstname>.output  float out  )
+
+
+   Ouput value
+
+   at_pid.N.tuneMode  bit in (default: 0)
+          ( OR <newinstname>.tuneMode  bit in (default: 0) )
+
+
+   0=PID, 1=tune.
+
+   at_pid.N.tuneStart  bit io (default: 0)
+          ( OR <newinstname>.tuneStart  bit io (default: 0) )
+
+
+   Set to 1 to start an auto-tune cycle.                         Clears automatically when the cycle has finished.
+------------------------------------------------------------------------------------------------------------------
+
+AUTHOR
+
+----------------
+   John Kasunich
+----------------
+
+LICENSE
+
+---------
+   GPL v2
+---------
+
+Machinekit Documentation 2015-11-01 AT_PID(9)

--- a/machinekit-documentation/components/bin2gray.asciidoc
+++ b/machinekit-documentation/components/bin2gray.asciidoc
@@ -1,0 +1,79 @@
+BIN2GRAY(9) HAL Component BIN2GRAY(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+--------------------------------------------------------------
+   bin2gray - convert a number to the gray-code representation
+--------------------------------------------------------------
+
+SYNOPSIS
+
+-----------
+   bin2gray
+-----------
+
+USAGE SYNOPSIS
+
+----------------------------------------------------------------------------------------------
+   loadrt bin2gray
+
+   newinst bin2gray <newinstname> [ pincount=N | iprefix=prefix ] [instanceparamX=X | argX=X ]
+----------------------------------------------------------------------------------------------
+
+DESCRIPTION
+
+-----------------------------------
+   Converts a number into gray-code
+-----------------------------------
+
+FUNCTIONS
+
+-------------------------------------
+   bin2gray.N.funct
+          ( OR <newinstname>.funct  )
+-------------------------------------
+
+PINS
+
+--------------------------------------------
+   bin2gray.N.in  u32 in
+          ( OR <newinstname>.in  u32 in  )
+
+
+   binary code in
+
+   bin2gray.N.out  u32 out
+          ( OR <newinstname>.out  u32 out  )
+
+
+   gray code out
+--------------------------------------------
+
+AUTHOR
+
+------------
+   andy pugh
+------------
+
+LICENSE
+
+------
+   GPL
+------
+
+Machinekit Documentation 2015-11-01 BIN2GRAY(9)

--- a/machinekit-documentation/components/biquad.asciidoc
+++ b/machinekit-documentation/components/biquad.asciidoc
@@ -1,0 +1,140 @@
+BIQUAD(9) HAL Component BIQUAD(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+-----------------------------
+   biquad - Biquad IIR filter
+-----------------------------
+
+SYNOPSIS
+
+---------
+   biquad
+---------
+
+USAGE SYNOPSIS
+
+--------------------------------------------------------------------------------------------
+   loadrt biquad
+
+   newinst biquad <newinstname> [ pincount=N | iprefix=prefix ] [instanceparamX=X | argX=X ]
+--------------------------------------------------------------------------------------------
+
+DESCRIPTION
+
+------------------------------------------------------------------------------------------------------------------
+   Biquad IIR filter. Implements the following transfer function: H(z) = (n0 + n1z-1 + n2z-2) / (1+ d1z-1 + d2z-2)
+------------------------------------------------------------------------------------------------------------------
+
+FUNCTIONS
+
+-----------------------------------------------------------------------
+   biquad.N.funct
+          ( OR <newinstname>.funct (requires a floating-point thread) )
+-----------------------------------------------------------------------
+
+PINS
+
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+   biquad.N.in  float in
+          ( OR <newinstname>.in  float in  )
+
+
+   Filter input.
+
+   biquad.N.out  float out
+          ( OR <newinstname>.out  float out  )
+
+
+   Filter output.
+
+   biquad.N.enable  bit in (default: false)
+          ( OR <newinstname>.enable  bit in (default: false) )
+
+
+   Filter enable. When false, the in is passed to out without any filtering. A transition from false to true causes filter coefficients to be calculated according to parameters
+
+   biquad.N.valid  bit out (default: false)
+          ( OR <newinstname>.valid  bit out (default: false) )
+
+
+   When false, indicates an error occured when caclulating filter coefficients.
+
+   biquad.N.type_  u32 io (default: 0)
+          ( OR <newinstname>.type_  u32 io (default: 0) )
+
+
+   Filter type determines the type of filter coefficients calculated. When 0, coefficients must be loaded directly. When 1, a low pass filter is created. When 2, a notch filter is created.
+
+   biquad.N.f0  float io (default: 250.0)
+          ( OR <newinstname>.f0  float io (default: 250.0) )
+
+
+   The corner frequency of the filter.
+
+   biquad.N.Q  float io (default: 0.7071)
+          ( OR <newinstname>.Q  float io (default: 0.7071) )
+
+
+   The Q of the filter.
+
+   biquad.N.d1  float io (default: 0.0)
+          ( OR <newinstname>.d1  float io (default: 0.0) )
+
+
+   1st-delayed denominator coef
+
+   biquad.N.d2  float io (default: 0.0)
+          ( OR <newinstname>.d2  float io (default: 0.0) )
+
+
+   2nd-delayed denominator coef
+
+   biquad.N.n0  float io (default: 1.0)
+          ( OR <newinstname>.n0  float io (default: 1.0) )
+
+
+   non-delayed numerator coef
+
+   biquad.N.n1  float io (default: 0.0)
+          ( OR <newinstname>.n1  float io (default: 0.0) )
+
+
+   1st-delayed numerator coef
+
+   biquad.N.n2  float io (default: 0.0)
+          ( OR <newinstname>.n2  float io (default: 0.0) )
+
+
+   2nd-delayed numerator coef
+
+   biquad.N.s1  float io (default: 0.0)
+          ( OR <newinstname>.s1  float io (default: 0.0) )
+
+
+   biquad.N.s2  float io (default: 0.0)
+          ( OR <newinstname>.s2  float io (default: 0.0) )
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+LICENSE
+
+------
+   GPL
+------
+
+Machinekit Documentation 2015-11-01 BIQUAD(9)

--- a/machinekit-documentation/components/bitslice.asciidoc
+++ b/machinekit-documentation/components/bitslice.asciidoc
@@ -1,0 +1,76 @@
+BITSLICE(9) HAL Component BITSLICE(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+-----------
+   bitslice
+-----------
+
+SYNOPSIS
+
+-----------
+   bitslice
+-----------
+
+USAGE SYNOPSIS
+
+----------------------------------------------------------------------------------------------
+   loadrt bitslice
+
+   newinst bitslice <newinstname> [ pincount=N | iprefix=prefix ] [instanceparamX=X | argX=X ]
+----------------------------------------------------------------------------------------------
+
+FUNCTIONS
+
+-------------------------------------
+   bitslice.N.funct
+          ( OR <newinstname>.funct  )
+-------------------------------------
+
+PINS
+
+-----------------------------------------------------------------
+   bitslice.N.in  u32 in
+          ( OR <newinstname>.in  u32 in  )
+
+
+   The input value
+
+   bitslice.N.out-##  bit out (MM=00..pincount)
+          ( OR <newinstname>.out-##  bit out (MM=00..pincount)  )
+-----------------------------------------------------------------
+
+INST_PARAMETERS
+
+-----------------------------
+   pincount int (default: 16)
+-----------------------------
+
+AUTHOR
+
+------------
+   Andy Pugh
+------------
+
+LICENSE
+
+--------
+   GPL2+
+--------
+
+Machinekit Documentation 2015-11-01 BITSLICE(9)

--- a/machinekit-documentation/components/bitwise.asciidoc
+++ b/machinekit-documentation/components/bitwise.asciidoc
@@ -1,0 +1,109 @@
+BITWISE(9) HAL Component BITWISE(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+------------------------------------------------------------------------
+   bitwise - Computes various bitwise operations on the two input values
+------------------------------------------------------------------------
+
+SYNOPSIS
+
+----------
+   bitwise
+----------
+
+USAGE SYNOPSIS
+
+---------------------------------------------------------------------------------------------
+   loadrt bitwise
+
+   newinst bitwise <newinstname> [ pincount=N | iprefix=prefix ] [instanceparamX=X | argX=X ]
+---------------------------------------------------------------------------------------------
+
+FUNCTIONS
+
+-------------------------------------
+   bitwise.N.funct
+          ( OR <newinstname>.funct  )
+-------------------------------------
+
+PINS
+
+-------------------------------------------------
+   bitwise.N.in0  u32 in
+          ( OR <newinstname>.in0  u32 in  )
+
+
+   First input value
+
+   bitwise.N.in1  u32 in
+          ( OR <newinstname>.in1  u32 in  )
+
+
+   Second input value
+
+   bitwise.N.out-and  u32 out
+          ( OR <newinstname>.out-and  u32 out  )
+
+
+   The bitwise AND of the two inputs
+
+   bitwise.N.out-or  u32 out
+          ( OR <newinstname>.out-or  u32 out  )
+
+
+   The bitwise OR of the two inputs
+
+   bitwise.N.out-xor  u32 out
+          ( OR <newinstname>.out-xor  u32 out  )
+
+
+   The bitwise XOR of the two inputs
+
+   bitwise.N.out-nand  u32 out
+          ( OR <newinstname>.out-nand  u32 out  )
+
+
+   The inverse of the bitwise AND
+
+   bitwise.N.out-nor  u32 out
+          ( OR <newinstname>.out-nor  u32 out  )
+
+
+   The inverse of the bitwise OR
+
+   bitwise.N.out-xnor  u32 out
+          ( OR <newinstname>.out-xnor  u32 out  )
+
+
+   The inverse of the bitwise XOR
+-------------------------------------------------
+
+AUTHOR
+
+------------
+   Andy Pugh
+------------
+
+LICENSE
+
+---------
+   GPL 2+
+---------
+
+Machinekit Documentation 2015-11-01 BITWISE(9)

--- a/machinekit-documentation/components/bldc_hall3.asciidoc
+++ b/machinekit-documentation/components/bldc_hall3.asciidoc
@@ -1,0 +1,191 @@
+BLDC_HALL3(9) HAL Component BLDC_HALL3(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+----------------------------------------------------------------------------------------
+   bldc_hall3 - 3-wire BLDC motor driver using Hall sensors and trapezoidal commutation.
+----------------------------------------------------------------------------------------
+
+SYNOPSIS
+
+--------------------------------------------------------------------------------------------------------------------------------------------------
+   The functionality of this component is now included in the generic "bldc" component. This component is likely to be removed in a future release
+--------------------------------------------------------------------------------------------------------------------------------------------------
+
+USAGE SYNOPSIS
+
+--------------------------------------------------------------------------------------------------------------------------------------------------
+   The functionality of this component is now included in the generic "bldc" component. This component is likely to be removed in a future release
+--------------------------------------------------------------------------------------------------------------------------------------------------
+
+DESCRIPTION
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+          This  component  produces a 3-wire bipolar output. This suits upstream drivers that interpret a negative input as a low-side drive and positive as a high-side drive. This includes the Hostmot2
+          3pwmgen function, which is likely to be the most common application of this component.
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+FUNCTIONS
+
+-----------------------------------------------------------------------
+   bldc_hall3.N.funct
+          ( OR <newinstname>.funct (requires a floating-point thread) )
+
+   Interpret Hall sensor patterns and set 3-phase amplitudes
+-----------------------------------------------------------------------
+
+PINS
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+   bldc_hall3.N.hall1  bit in
+          ( OR <newinstname>.hall1  bit in  )
+
+
+   Hall sensor signal 1
+
+   bldc_hall3.N.hall2  bit in
+          ( OR <newinstname>.hall2  bit in  )
+
+
+   Hall sensor signal 2
+
+   bldc_hall3.N.hall3  bit in
+          ( OR <newinstname>.hall3  bit in  )
+
+
+   Hall sensor signal 3
+
+   bldc_hall3.N.value  float in
+          ( OR <newinstname>.value  float in  )
+
+
+   PWM master amplitude input
+
+   bldc_hall3.N.dir  bit in
+          ( OR <newinstname>.dir  bit in  )
+
+
+   Forwards / reverse selection. Negative PWM amplitudes will also reverse the motor and there will generally be a pattern that runs the motor in each direction too.
+
+   bldc_hall3.N.A-value  float out
+          ( OR <newinstname>.A-value  float out  )
+
+
+   Output amplitude for phase A
+
+   bldc_hall3.N.B-value  float out
+          ( OR <newinstname>.B-value  float out  )
+
+
+   Output amplitude for phase B
+
+   bldc_hall3.N.C-value  float out
+          ( OR <newinstname>.C-value  float out  )
+
+
+   Output amplitude for phase C
+
+   bldc_hall3.N.pattern  u32 io (default: 25)
+          ( OR <newinstname>.pattern  u32 io (default: 25) )
+
+
+   Commutation pattern to use, from 0 to 47. Default is type 25.  Every plausible combination is included. The table shows the excitation pattern along the top, and the pattern code  on  the  left  hand
+          side.  The  table  entries are the hall patterns in H1, H2, H3 order.  Common patterns are: 0 (30 degree commutation) and 26, its reverse.  17 (120 degree).  18 (alternate 60 degree).  21 (300
+          degree, Bodine).  22 (240 degree).  25 (60 degree commutation).
+
+          Note that a number of incorrect commutations will have non-zero net torque which might look as if they work, but don't really.
+
+          If your motor lacks documentation it might be worth trying every pattern.
+
+
+
+          ┌────────────────────────────────────────┐
+          │         Phases, Source - Sink          │
+          ├────┬───────────────────────────────────┤
+          │pat │ B-A   C-A   C-B   A-B   A-C   B-C │
+          ├────┼───────────────────────────────────┤
+          │ 0  │ 000   001   011   111   110   100 │
+          │ 1  │ 001   000   010   110   111   101 │
+          │ 2  │ 000   010   011   111   101   100 │
+          │ 3  │ 001   011   010   110   100   101 │
+          │ 4  │ 010   011   001   101   100   110 │
+          │ 5  │ 011   010   000   100   101   111 │
+          │ 6  │ 010   000   001   101   111   110 │
+          │ 7  │ 011   001   000   100   110   111 │
+          │ 8  │ 000   001   101   111   110   010 │
+          │ 9  │ 001   000   100   110   111   011 │
+          │10  │ 000   010   110   111   101   001 │
+          │11  │ 001   011   111   110   100   000 │
+          │12  │ 010   011   111   101   100   000 │
+          │13  │ 011   010   110   100   101   001 │
+          │14  │ 010   000   100   101   111   011 │
+          │15  │ 011   001   101   100   110   010 │
+          │16  │ 000   100   101   111   011   010 │
+          │17  │ 001   101   100   110   010   011 │
+          │18  │ 000   100   110   111   011   001 │
+          │19  │ 001   101   111   110   010   000 │
+          │20  │ 010   110   111   101   001   000 │
+          │21  │ 011   111   110   100   000   001 │
+          │22  │ 010   110   100   101   001   011 │
+          │23  │ 011   111   101   100   000   010 │
+          │24  │ 100   101   111   011   010   000 │
+          │25  │ 101   100   110   010   011   001 │
+          │26  │ 100   110   111   011   001   000 │
+          │27  │ 101   111   110   010   000   001 │
+          │28  │ 110   111   101   001   000   010 │
+          │29  │ 111   110   100   000   001   011 │
+          │30  │ 110   100   101   001   011   010 │
+          │31  │ 111   101   100   000   010   011 │
+          │32  │ 100   101   001   011   010   110 │
+          │33  │ 101   100   000   010   011   111 │
+          │34  │ 100   110   010   011   001   101 │
+          │35  │ 101   111   011   010   000   100 │
+          │36  │ 110   111   011   001   000   100 │
+          │37  │ 111   110   010   000   001   101 │
+          │38  │ 110   100   000   001   011   111 │
+          │39  │ 111   101   001   000   010   110 │
+          │40  │ 100   000   001   011   111   110 │
+          │41  │ 101   001   000   010   110   111 │
+          │42  │ 100   000   010   011   111   101 │
+          │43  │ 101   001   011   010   110   100 │
+          │44  │ 110   010   011   001   101   100 │
+          │45  │ 111   011   010   000   100   101 │
+          │46  │ 110   010   000   001   101   111 │
+          │47  │ 111   011   001   000   100   110 │
+          └────┴───────────────────────────────────┘
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+SEE ALSO
+
+------------------------------------------------------------
+          bldc_hall6 6-wire unipolar driver for BLDC motors.
+------------------------------------------------------------
+
+AUTHOR
+
+------------
+   Andy Pugh
+------------
+
+LICENSE
+
+------
+   GPL
+------
+
+Machinekit Documentation 2015-11-01 BLDC_HALL3(9)

--- a/machinekit-documentation/components/blend.asciidoc
+++ b/machinekit-documentation/components/blend.asciidoc
@@ -1,0 +1,85 @@
+BLEND(9) HAL Component BLEND(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+----------------------------------------------------------
+   blend - Perform linear interpolation between two values
+----------------------------------------------------------
+
+SYNOPSIS
+
+--------
+   blend
+--------
+
+USAGE SYNOPSIS
+
+-------------------------------------------------------------------------------------------
+   loadrt blend
+
+   newinst blend <newinstname> [ pincount=N | iprefix=prefix ] [instanceparamX=X | argX=X ]
+-------------------------------------------------------------------------------------------
+
+FUNCTIONS
+
+-----------------------------------------------------------------------
+   blend.N.funct
+          ( OR <newinstname>.funct (requires a floating-point thread) )
+-----------------------------------------------------------------------
+
+PINS
+
+-----------------------------------------------------------------------------------------------------------------------------------------------------------
+   blend.N.in1  float in
+          ( OR <newinstname>.in1  float in  )
+
+
+   First input.  If select is equal to 1.0, the output is equal to in1
+
+   blend.N.in2  float in
+          ( OR <newinstname>.in2  float in  )
+
+
+   Second input.  If select is equal to 0.0, the output is equal to in2
+
+   blend.N.select  float in
+          ( OR <newinstname>.select  float in  )
+
+
+   Select input.  For values between 0.0 and 1.0, the output changes linearly from in2 to in1
+
+   blend.N.out  float out
+          ( OR <newinstname>.out  float out  )
+
+
+   Output value.
+
+   blend.N.open  bit io
+          ( OR <newinstname>.open  bit io  )
+
+
+   If true, select values outside the range 0.0 to 1.0 give values outside the range in2 to in1.  If false, outputs are clamped to the the range in2 to in1
+-----------------------------------------------------------------------------------------------------------------------------------------------------------
+
+LICENSE
+
+------
+   GPL
+------
+
+Machinekit Documentation 2015-11-01 BLEND(9)

--- a/machinekit-documentation/components/clarke2.asciidoc
+++ b/machinekit-documentation/components/clarke2.asciidoc
@@ -1,0 +1,91 @@
+CLARKE2(9) HAL Component CLARKE2(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+--------------------------------------------------
+   clarke2 - Two input version of Clarke transform
+--------------------------------------------------
+
+SYNOPSIS
+
+----------
+   clarke2
+----------
+
+USAGE SYNOPSIS
+
+---------------------------------------------------------------------------------------------
+   loadrt clarke2
+
+   newinst clarke2 <newinstname> [ pincount=N | iprefix=prefix ] [instanceparamX=X | argX=X ]
+---------------------------------------------------------------------------------------------
+
+DESCRIPTION
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+   The Clarke transform can be used to translate a vector quantity from a three phase system (three components 120 degrees apart) to a two phase Cartesian system.
+
+   clarke2  implements  a  special case of the Clarke transform, which only needs two of the three input phases.  In a three wire three phase system, the sum of the three phase currents or voltages must
+   always be zero.  As a result only two of the three are needed to completely define the current or voltage.  clarke2 assumes that the sum is zero, so it only uses phases A and B of the  input.   Since
+   the H (homopolar) output will always be zero in this case, it is not generated.
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+FUNCTIONS
+
+-----------------------------------------------------------------------
+   clarke2.N.funct
+          ( OR <newinstname>.funct (requires a floating-point thread) )
+-----------------------------------------------------------------------
+
+PINS
+
+--------------------------------------------
+   clarke2.N.a  float in
+          ( OR <newinstname>.a  float in  )
+
+
+   clarke2.N.b  float in
+          ( OR <newinstname>.b  float in  )
+
+
+   first two phases of three phase input
+
+   clarke2.N.x  float out
+          ( OR <newinstname>.x  float out  )
+
+
+   clarke2.N.y  float out
+          ( OR <newinstname>.y  float out  )
+
+
+   cartesian components of output
+--------------------------------------------
+
+SEE ALSO
+
+---------------------------------------------------------------------
+   clarke3 for the general case, clarkeinv for the inverse transform.
+---------------------------------------------------------------------
+
+LICENSE
+
+------
+   GPL
+------
+
+Machinekit Documentation 2015-11-01 CLARKE2(9)

--- a/machinekit-documentation/components/clarke3.asciidoc
+++ b/machinekit-documentation/components/clarke3.asciidoc
@@ -1,0 +1,100 @@
+CLARKE3(9) HAL Component CLARKE3(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+----------------------------------------------------
+   clarke3 - Clarke (3 phase to cartesian) transform
+----------------------------------------------------
+
+SYNOPSIS
+
+----------
+   clarke3
+----------
+
+USAGE SYNOPSIS
+
+---------------------------------------------------------------------------------------------
+   loadrt clarke3
+
+   newinst clarke3 <newinstname> [ pincount=N | iprefix=prefix ] [instanceparamX=X | argX=X ]
+---------------------------------------------------------------------------------------------
+
+DESCRIPTION
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+   The Clarke transform can be used to translate a vector quantity from a three phase system (three components 120 degrees apart) to a two phase Cartesian system (plus a homopolar component if the three
+          phases don't sum to zero).
+
+   clarke3 implements the general case of the transform, using all three phases.  If the three phases are known to sum to zero, see clarke2 for a simpler version.
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+FUNCTIONS
+
+-----------------------------------------------------------------------
+   clarke3.N.funct
+          ( OR <newinstname>.funct (requires a floating-point thread) )
+-----------------------------------------------------------------------
+
+PINS
+
+--------------------------------------------
+   clarke3.N.a  float in
+          ( OR <newinstname>.a  float in  )
+
+
+   clarke3.N.b  float in
+          ( OR <newinstname>.b  float in  )
+
+
+   clarke3.N.c  float in
+          ( OR <newinstname>.c  float in  )
+
+
+   three phase input vector
+
+   clarke3.N.x  float out
+          ( OR <newinstname>.x  float out  )
+
+
+   clarke3.N.y  float out
+          ( OR <newinstname>.y  float out  )
+
+
+   cartesian components of output
+
+   clarke3.N.h  float out
+          ( OR <newinstname>.h  float out  )
+
+
+   homopolar component of output
+--------------------------------------------
+
+SEE ALSO
+
+-----------------------------------------------------------------------
+   clarke2 for the 'a+b+c=0' case, clarkeinv for the inverse transform.
+-----------------------------------------------------------------------
+
+LICENSE
+
+------
+   GPL
+------
+
+Machinekit Documentation 2015-11-01 CLARKE3(9)

--- a/machinekit-documentation/components/clarkeinv.asciidoc
+++ b/machinekit-documentation/components/clarkeinv.asciidoc
@@ -1,0 +1,103 @@
+CLARKEINV(9) HAL Component CLARKEINV(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+---------------------------------------
+   clarkeinv - Inverse Clarke transform
+---------------------------------------
+
+SYNOPSIS
+
+------------
+   clarkeinv
+------------
+
+USAGE SYNOPSIS
+
+-----------------------------------------------------------------------------------------------
+   loadrt clarkeinv
+
+   newinst clarkeinv <newinstname> [ pincount=N | iprefix=prefix ] [instanceparamX=X | argX=X ]
+-----------------------------------------------------------------------------------------------
+
+DESCRIPTION
+
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+   The inverse Clarke transform can be used rotate a vector quantity and then translate it from Cartesian coordinate system to a three phase system (three components 120 degrees apart).
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+FUNCTIONS
+
+-----------------------------------------------------------------------
+   clarkeinv.N.funct
+          ( OR <newinstname>.funct (requires a floating-point thread) )
+-----------------------------------------------------------------------
+
+PINS
+
+--------------------------------------------------
+   clarkeinv.N.x  float in
+          ( OR <newinstname>.x  float in  )
+
+
+   clarkeinv.N.y  float in
+          ( OR <newinstname>.y  float in  )
+
+
+   cartesian components of input
+
+   clarkeinv.N.h  float in
+          ( OR <newinstname>.h  float in  )
+
+
+   homopolar component of input (usually zero)
+
+   clarkeinv.N.theta  float in
+          ( OR <newinstname>.theta  float in  )
+
+
+   rotation angle: 0.00 to 1.00 = 0 to 360 degrees
+
+   clarkeinv.N.a  float out
+          ( OR <newinstname>.a  float out  )
+
+
+   clarkeinv.N.b  float out
+          ( OR <newinstname>.b  float out  )
+
+
+   clarkeinv.N.c  float out
+          ( OR <newinstname>.c  float out  )
+
+
+   three phase output vector
+--------------------------------------------------
+
+SEE ALSO
+
+-------------------------------------------------
+   clarke2 and clarke3 for the forward transform.
+-------------------------------------------------
+
+LICENSE
+
+------
+   GPL
+------
+
+Machinekit Documentation 2015-11-01 CLARKEINV(9)

--- a/machinekit-documentation/components/comp.asciidoc
+++ b/machinekit-documentation/components/comp.asciidoc
@@ -1,0 +1,90 @@
+COMP(9) HAL Component COMP(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+----------------------------------------------
+   comp - Two input comparator with hysteresis
+----------------------------------------------
+
+SYNOPSIS
+
+-------
+   comp
+-------
+
+USAGE SYNOPSIS
+
+------------------------------------------------------------------------------------------
+   loadrt comp
+
+   newinst comp <newinstname> [ pincount=N | iprefix=prefix ] [instanceparamX=X | argX=X ]
+------------------------------------------------------------------------------------------
+
+FUNCTIONS
+
+-----------------------------------------------------------------------
+   comp.N.funct
+          ( OR <newinstname>.funct (requires a floating-point thread) )
+
+   Update the comparator
+-----------------------------------------------------------------------
+
+PINS
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+   comp.N.in0  float in
+          ( OR <newinstname>.in0  float in  )
+
+
+   Inverting input to the comparator
+
+   comp.N.in1  float in
+          ( OR <newinstname>.in1  float in  )
+
+
+   Non-inverting input to the comparator
+
+   comp.N.out  bit out
+          ( OR <newinstname>.out  bit out  )
+
+
+   Normal output. True when in1 > in0 (see parameter hyst for details)
+
+   comp.N.equal  bit out
+          ( OR <newinstname>.equal  bit out  )
+
+
+   Match output.  True when difference between in1 and in0 is less than hyst/2
+
+   comp.N.hyst  float in (default: 0.0)
+          ( OR <newinstname>.hyst  float in (default: 0.0) )
+
+
+   Hysteresis of the comparator (default 0.0)
+
+          With zero hysteresis, the output is true when in1 > in0.  With nonzero hysteresis, the output switches on and off at two different values, separated by distance hyst around the point where in1
+          = in0.  Keep in mind that floating point calculations are never absolute and it is wise to always set hyst if you intend to use equal
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+LICENSE
+
+------
+   GPL
+------
+
+Machinekit Documentation 2015-11-01 COMP(9)

--- a/machinekit-documentation/components/constant.asciidoc
+++ b/machinekit-documentation/components/constant.asciidoc
@@ -1,0 +1,62 @@
+CONSTANT(9) HAL Component CONSTANT(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+-------------------------------------------------------
+   constant - Use a parameter to set the value of a pin
+-------------------------------------------------------
+
+SYNOPSIS
+
+-----------
+   constant
+-----------
+
+USAGE SYNOPSIS
+
+----------------------------------------------------------------------------------------------
+   loadrt constant
+
+   newinst constant <newinstname> [ pincount=N | iprefix=prefix ] [instanceparamX=X | argX=X ]
+----------------------------------------------------------------------------------------------
+
+FUNCTIONS
+
+-----------------------------------------------------------------------
+   constant.N.funct
+          ( OR <newinstname>.funct (requires a floating-point thread) )
+-----------------------------------------------------------------------
+
+PINS
+
+-----------------------------------------------
+   constant.N.out  float out
+          ( OR <newinstname>.out  float out  )
+
+
+   constant.N.value  float io
+          ( OR <newinstname>.value  float io  )
+-----------------------------------------------
+
+LICENSE
+
+------
+   GPL
+------
+
+Machinekit Documentation 2015-11-01 CONSTANT(9)

--- a/machinekit-documentation/components/ddt.asciidoc
+++ b/machinekit-documentation/components/ddt.asciidoc
@@ -1,0 +1,62 @@
+DDT(9) HAL Component DDT(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+-----------------------------------------------------
+   ddt - Compute the derivative of the input function
+-----------------------------------------------------
+
+SYNOPSIS
+
+------
+   ddt
+------
+
+USAGE SYNOPSIS
+
+-----------------------------------------------------------------------------------------
+   loadrt ddt
+
+   newinst ddt <newinstname> [ pincount=N | iprefix=prefix ] [instanceparamX=X | argX=X ]
+-----------------------------------------------------------------------------------------
+
+FUNCTIONS
+
+-----------------------------------------------------------------------
+   ddt.N.funct
+          ( OR <newinstname>.funct (requires a floating-point thread) )
+-----------------------------------------------------------------------
+
+PINS
+
+----------------------------------------------
+   ddt.N.in  float in
+          ( OR <newinstname>.in  float in  )
+
+
+   ddt.N.out  float out
+          ( OR <newinstname>.out  float out  )
+----------------------------------------------
+
+LICENSE
+
+------
+   GPL
+------
+
+Machinekit Documentation 2015-11-01 DDT(9)

--- a/machinekit-documentation/components/deadzone.asciidoc
+++ b/machinekit-documentation/components/deadzone.asciidoc
@@ -1,0 +1,76 @@
+DEADZONE(9) HAL Component DEADZONE(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+-------------------------------------------------------
+   deadzone - Return the center if within the threshold
+-------------------------------------------------------
+
+SYNOPSIS
+
+-----------
+   deadzone
+-----------
+
+USAGE SYNOPSIS
+
+----------------------------------------------------------------------------------------------
+   loadrt deadzone
+
+   newinst deadzone <newinstname> [ pincount=N | iprefix=prefix ] [instanceparamX=X | argX=X ]
+----------------------------------------------------------------------------------------------
+
+FUNCTIONS
+
+-----------------------------------------------------------------------
+   deadzone.N.funct
+          ( OR <newinstname>.funct (requires a floating-point thread) )
+
+   Update out based on in and the parameters.
+-----------------------------------------------------------------------
+
+PINS
+
+------------------------------------------------------------------
+   deadzone.N.center  float io (default: 0.0)
+          ( OR <newinstname>.center  float io (default: 0.0) )
+
+
+   The center of the dead zone
+
+   deadzone.N.threshhold  float io (default: 1.0)
+          ( OR <newinstname>.threshhold  float io (default: 1.0) )
+
+
+   The dead zone is center ± (threshhold/2)
+
+   deadzone.N.in  float in
+          ( OR <newinstname>.in  float in  )
+
+
+   deadzone.N.out  float out
+          ( OR <newinstname>.out  float out  )
+------------------------------------------------------------------
+
+LICENSE
+
+------
+   GPL
+------
+
+Machinekit Documentation 2015-11-01 DEADZONE(9)

--- a/machinekit-documentation/components/debounce.asciidoc
+++ b/machinekit-documentation/components/debounce.asciidoc
@@ -1,0 +1,82 @@
+DEBOUNCE(9) HAL Component DEBOUNCE(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+------------------------------------------------
+   debounce - Debounce filter for Machinekit HAL
+------------------------------------------------
+
+SYNOPSIS
+
+-----------
+   debounce
+-----------
+
+USAGE SYNOPSIS
+
+----------------------------------------------------------------------------------------------
+   loadrt debounce
+
+   newinst debounce <newinstname> [ pincount=N | iprefix=prefix ] [instanceparamX=X | argX=X ]
+----------------------------------------------------------------------------------------------
+
+FUNCTIONS
+
+-----------------------------------------------------------------------
+   debounce.N.funct
+          ( OR <newinstname>.funct (requires a floating-point thread) )
+-----------------------------------------------------------------------
+
+PINS
+
+---------------------------------------------------------------
+   debounce.N.#.in  bit in (M=0..pincount)
+          ( OR <newinstname>.#.in  bit in (M=0..pincount)  )
+
+
+   debounce.N.#.out  bit out (M=0..pincount)
+          ( OR <newinstname>.#.out  bit out (M=0..pincount)  )
+
+
+   debounce.N.#.state  s32 io (M=0..pincount)
+          ( OR <newinstname>.#.state  s32 io (M=0..pincount)  )
+
+
+   debounce.N.delay  s32 io (default: 5)
+          ( OR <newinstname>.delay  s32 io (default: 5) )
+---------------------------------------------------------------
+
+INST_PARAMETERS
+
+----------------------------
+   pincount int (default: 8)
+----------------------------
+
+AUTHOR
+
+-----------------------------------
+   John Kasunich, adapted by ArcEye
+-----------------------------------
+
+LICENSE
+
+------
+   GPL
+------
+
+Machinekit Documentation 2015-11-01 DEBOUNCE(9)

--- a/machinekit-documentation/components/div2.asciidoc
+++ b/machinekit-documentation/components/div2.asciidoc
@@ -1,0 +1,79 @@
+DIV2(9) HAL Component DIV2(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+--------------------------------
+   div2 - Quotient of two inputs
+--------------------------------
+
+SYNOPSIS
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+   The output will be quotient of the two inputs, ie out = in0/in1.  The parameter deadband can be used to control how close to 0 the denominator can be before the output is clamped to 0.  deadband must
+          be at least 1e-8, and must be positive.
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+USAGE SYNOPSIS
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+   The output will be quotient of the two inputs, ie out = in0/in1.  The parameter deadband can be used to control how close to 0 the denominator can be before the output is clamped to 0.  deadband must
+          be at least 1e-8, and must be positive.
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+FUNCTIONS
+
+-----------------------------------------------------------------------
+   div2.N.funct
+          ( OR <newinstname>.funct (requires a floating-point thread) )
+-----------------------------------------------------------------------
+
+PINS
+
+-----------------------------------------------------------------
+   div2.N.in0  float in
+          ( OR <newinstname>.in0  float in  )
+
+
+   dividend
+
+   div2.N.in1  float in
+          ( OR <newinstname>.in1  float in  )
+
+
+   divisor
+
+   div2.N.out  float out
+          ( OR <newinstname>.out  float out  )
+
+
+   out = in0 / in1
+
+   div2.N.deadband  float io
+          ( OR <newinstname>.deadband  float io  )
+
+
+   The out will be zero if in1 is between -deadband and +deadband
+-----------------------------------------------------------------
+
+LICENSE
+
+------
+   GPL
+------
+
+Machinekit Documentation 2015-11-01 DIV2(9)

--- a/machinekit-documentation/components/edge.asciidoc
+++ b/machinekit-documentation/components/edge.asciidoc
@@ -1,0 +1,103 @@
+EDGE(9) HAL Component EDGE(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+-----------------------
+   edge - Edge detector
+-----------------------
+
+SYNOPSIS
+
+-------
+   edge
+-------
+
+USAGE SYNOPSIS
+
+------------------------------------------------------------------------------------------
+   loadrt edge
+
+   newinst edge <newinstname> [ pincount=N | iprefix=prefix ] [instanceparamX=X | argX=X ]
+------------------------------------------------------------------------------------------
+
+FUNCTIONS
+
+-----------------------------------------
+   edge.N.funct
+          ( OR <newinstname>.funct  )
+
+   Produce output pulses from input edges
+-----------------------------------------
+
+PINS
+
+-----------------------------------------------------------------------------------------
+   edge.N.in  bit in
+          ( OR <newinstname>.in  bit in  )
+
+
+   edge.N.out  bit out
+          ( OR <newinstname>.out  bit out  )
+
+
+   Goes high when the desired edge is seen on 'in'
+
+   edge.N.out_invert  bit out
+          ( OR <newinstname>.out_invert  bit out  )
+
+
+   Goes low when the desired edge is seen on 'in'
+
+   edge.N.both  bit io (default: false)
+          ( OR <newinstname>.both  bit io (default: false) )
+
+
+   If true, selects both edges.  Otherwise, selects one edge according to in-edge
+
+   edge.N.in_edge  bit io (default: true)
+          ( OR <newinstname>.in_edge  bit io (default: true) )
+
+
+   If both is false, selects the one desired edge: true means falling, false means rising
+
+   edge.N.out_width_ns  s32 io (default: 0)
+          ( OR <newinstname>.out_width_ns  s32 io (default: 0) )
+
+
+   Time in nanoseconds of the output pulse
+
+   edge.N.time_left_ns  s32 out
+          ( OR <newinstname>.time_left_ns  s32 out  )
+
+
+   Time left in this output pulse
+
+   edge.N.last_in  bit out
+          ( OR <newinstname>.last_in  bit out  )
+
+
+   Previous input value
+-----------------------------------------------------------------------------------------
+
+LICENSE
+
+------
+   GPL
+------
+
+Machinekit Documentation 2015-11-01 EDGE(9)

--- a/machinekit-documentation/components/estop_latch.asciidoc
+++ b/machinekit-documentation/components/estop_latch.asciidoc
@@ -1,0 +1,79 @@
+ESTOP_LATCH(9) HAL Component ESTOP_LATCH(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+   estop_latch  - ESTOP latch which sets ok-out true and fault-out false only if ok-in is true, fault-in is false, and a rising edge is seen on reset.  While ok-out is true, watchdog toggles, and can be
+          used for chargepumps or similar needs.
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+SYNOPSIS
+
+--------------
+   estop_latch
+--------------
+
+USAGE SYNOPSIS
+
+-------------------------------------------------------------------------------------------------
+   loadrt estop_latch
+
+   newinst estop_latch <newinstname> [ pincount=N | iprefix=prefix ] [instanceparamX=X | argX=X ]
+-------------------------------------------------------------------------------------------------
+
+FUNCTIONS
+
+-------------------------------------
+   estop_latch.N.funct
+          ( OR <newinstname>.funct  )
+-------------------------------------
+
+PINS
+
+--------------------------------------------------
+   estop_latch.N.ok_in  bit in
+          ( OR <newinstname>.ok_in  bit in  )
+
+
+   estop_latch.N.fault_in  bit in
+          ( OR <newinstname>.fault_in  bit in  )
+
+
+   estop_latch.N.reset  bit in
+          ( OR <newinstname>.reset  bit in  )
+
+
+   estop_latch.N.ok_out  bit out
+          ( OR <newinstname>.ok_out  bit out  )
+
+
+   estop_latch.N.fault_out  bit out
+          ( OR <newinstname>.fault_out  bit out  )
+
+
+   estop_latch.N.watchdog  bit out
+          ( OR <newinstname>.watchdog  bit out  )
+--------------------------------------------------
+
+LICENSE
+
+------
+   GPL
+------
+
+Machinekit Documentation 2015-11-01 ESTOP_LATCH(9)

--- a/machinekit-documentation/components/feedcomp.asciidoc
+++ b/machinekit-documentation/components/feedcomp.asciidoc
@@ -1,0 +1,91 @@
+FEEDCOMP(9) HAL Component FEEDCOMP(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+----------------------------------------------------------------------------------
+   feedcomp - Multiply the input by the ratio of current velocity to the feed rate
+----------------------------------------------------------------------------------
+
+SYNOPSIS
+
+-----------
+   feedcomp
+-----------
+
+USAGE SYNOPSIS
+
+----------------------------------------------------------------------------------------------
+   loadrt feedcomp
+
+   newinst feedcomp <newinstname> [ pincount=N | iprefix=prefix ] [instanceparamX=X | argX=X ]
+----------------------------------------------------------------------------------------------
+
+FUNCTIONS
+
+-----------------------------------------------------------------------
+   feedcomp.N.funct
+          ( OR <newinstname>.funct (requires a floating-point thread) )
+-----------------------------------------------------------------------
+
+PINS
+
+----------------------------------------------
+   feedcomp.N.out  float out
+          ( OR <newinstname>.out  float out  )
+
+
+   Proportionate output value
+
+   feedcomp.N.in  float in
+          ( OR <newinstname>.in  float in  )
+
+
+   Reference value
+
+   feedcomp.N.enable  bit in
+          ( OR <newinstname>.enable  bit in  )
+
+
+   Turn compensation on or off
+
+   feedcomp.N.vel  float in
+          ( OR <newinstname>.vel  float in  )
+
+
+   Current velocity
+
+   feedcomp.N.feed  float io
+          ( OR <newinstname>.feed  float io  )
+
+
+   Feed rate reference value
+----------------------------------------------
+
+NOTES
+
+-----------------------------------------
+   Note that if enable is false, out = in
+-----------------------------------------
+
+LICENSE
+
+------
+   GPL
+------
+
+Machinekit Documentation 2015-11-01 FEEDCOMP(9)

--- a/machinekit-documentation/components/flipflop.asciidoc
+++ b/machinekit-documentation/components/flipflop.asciidoc
@@ -1,0 +1,85 @@
+FLIPFLOP(9) HAL Component FLIPFLOP(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+------------------------------
+   flipflop - D type flip-flop
+------------------------------
+
+SYNOPSIS
+
+-----------
+   flipflop
+-----------
+
+USAGE SYNOPSIS
+
+----------------------------------------------------------------------------------------------
+   loadrt flipflop
+
+   newinst flipflop <newinstname> [ pincount=N | iprefix=prefix ] [instanceparamX=X | argX=X ]
+----------------------------------------------------------------------------------------------
+
+FUNCTIONS
+
+-------------------------------------
+   flipflop.N.funct
+          ( OR <newinstname>.funct  )
+-------------------------------------
+
+PINS
+
+---------------------------------------------
+   flipflop.N.data_  bit in
+          ( OR <newinstname>.data_  bit in  )
+
+
+   data input
+
+   flipflop.N.clk  bit in
+          ( OR <newinstname>.clk  bit in  )
+
+
+   clock, rising edge writes data to out
+
+   flipflop.N.set  bit in
+          ( OR <newinstname>.set  bit in  )
+
+
+   when true, force out true
+
+   flipflop.N.reset  bit in
+          ( OR <newinstname>.reset  bit in  )
+
+
+   when true, force out false; overrides set
+
+   flipflop.N.out  bit io
+          ( OR <newinstname>.out  bit io  )
+
+
+   output
+---------------------------------------------
+
+LICENSE
+
+------
+   GPL
+------
+
+Machinekit Documentation 2015-11-01 FLIPFLOP(9)

--- a/machinekit-documentation/components/gantry.asciidoc
+++ b/machinekit-documentation/components/gantry.asciidoc
@@ -1,0 +1,137 @@
+GANTRY(9) HAL Component GANTRY(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+-----------------------------------------------------------------------------------
+   gantry - Machinekit HAL component for driving multiple joints from a single axis
+-----------------------------------------------------------------------------------
+
+SYNOPSIS
+
+---------
+   gantry
+---------
+
+USAGE SYNOPSIS
+
+--------------------------------------------------------------------------------------------
+   loadrt gantry
+
+   newinst gantry <newinstname> [ pincount=N | iprefix=prefix ] [instanceparamX=X | argX=X ]
+--------------------------------------------------------------------------------------------
+
+DESCRIPTION
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+          Drives multiple physical motors (joints) from a single axis input
+
+   The `pincount' value is the number of joints to control.  Two is typical, but up to seven is supported (a three joint setup has been tested with hardware).
+
+   All  controlled  joints track the commanded position (with a per-joint offset) unless in the process of homing.  Homing is when the commanded position is moving towards the homing switches (as deter‐
+   mined by the sign of search-vel) and the joint home switches are not all in the same state.  When the system is homing and a joint home switch activates, the command  value  sent  to  that  joint  is
+   "frozen" and the joint offset value is updated instead.  Once all home switches are active, there are no more adjustments made to the offset values and all joints run in lock-step once more.
+
+   For  best  results,  set  HOME_SEARCH_VEL  and  HOME_LATCH_VEL  to  the  same  direction  and  as slow as practical.  When a joint home switch trips, the commanded velocity will drop immediately from
+   HOME_SEARCH_VEL to zero, with no limit on accleration.
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+FUNCTIONS
+
+-----------------------------------------------------------------------------
+   gantry.N.read.funct
+          ( OR <newinstname>.read.funct (requires a floating-point thread) )
+
+   Update position-fb and home/limit outputs based on joint values
+
+   gantry.N.write.funct
+          ( OR <newinstname>.write.funct (requires a floating-point thread) )
+
+   Update joint pos-cmd outputs based on position-cmd in
+-----------------------------------------------------------------------------
+
+PINS
+
+-----------------------------------------------------------------------------
+   gantry.N.joint.##.pos-cmd  float out (MM=00..pincount)
+          ( OR <newinstname>.joint.##.pos-cmd  float out (MM=00..pincount)  )
+
+
+   Per-joint commanded position
+
+   gantry.N.joint.##.pos-fb  float in (MM=00..pincount)
+          ( OR <newinstname>.joint.##.pos-fb  float in (MM=00..pincount)  )
+
+
+   Per-joint position feedback
+
+   gantry.N.joint.##.home  bit in (MM=00..pincount)
+          ( OR <newinstname>.joint.##.home  bit in (MM=00..pincount)  )
+
+
+   Per-joint home switch
+
+   gantry.N.joint.##.offset  float out (MM=00..pincount)
+          ( OR <newinstname>.joint.##.offset  float out (MM=00..pincount)  )
+
+
+   (debugging) Per-joint offset value, updated when homing
+
+   gantry.N.position-cmd  float in
+          ( OR <newinstname>.position-cmd  float in  )
+
+
+   Commanded position from motion
+
+   gantry.N.position-fb  float out
+          ( OR <newinstname>.position-fb  float out  )
+
+
+   Position feedback to motion
+
+   gantry.N.home  bit out
+          ( OR <newinstname>.home  bit out  )
+
+
+   Combined home signal, true if all joint home inputs are true
+
+   gantry.N.limit  bit out
+          ( OR <newinstname>.limit  bit out  )
+
+
+   Combined limit signal, true if any joint home input is true
+
+   gantry.N.search-vel  float in
+          ( OR <newinstname>.search-vel  float in  )
+
+
+   HOME_SEARCH_VEL from ini file
+-----------------------------------------------------------------------------
+
+INST_PARAMETERS
+
+----------------------------
+   pincount int (default: 7)
+----------------------------
+
+LICENSE
+
+------
+   GPL
+------
+
+Machinekit Documentation 2015-11-01 GANTRY(9)

--- a/machinekit-documentation/components/gearchange.asciidoc
+++ b/machinekit-documentation/components/gearchange.asciidoc
@@ -1,0 +1,121 @@
+GEARCHANGE(9) HAL Component GEARCHANGE(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+------------------------------------------------
+   gearchange - Select from one two speed ranges
+------------------------------------------------
+
+SYNOPSIS
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+   The  output will be a value scaled for the selected gear, and clamped to the min/max values for that gear.  The scale of gear 1 is assumed to be 1, so the output device scale should be chosen accord‐
+          ingly.  The scale of gear 2 is relative to gear 1, so if gear 2 runs the spindle 2.5 times as fast as gear 1, scale2 should be set to 2.5.
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+USAGE SYNOPSIS
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+   The output will be a value scaled for the selected gear, and clamped to the min/max values for that gear.  The scale of gear 1 is assumed to be 1, so the output device scale should be chosen  accord‐
+          ingly.  The scale of gear 2 is relative to gear 1, so if gear 2 runs the spindle 2.5 times as fast as gear 1, scale2 should be set to 2.5.
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+FUNCTIONS
+
+-----------------------------------------------------------------------
+   gearchange.N.funct
+          ( OR <newinstname>.funct (requires a floating-point thread) )
+-----------------------------------------------------------------------
+
+PINS
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------
+   gearchange.N.sel  bit in
+          ( OR <newinstname>.sel  bit in  )
+
+
+   Gear selection input
+
+   gearchange.N.speed_in  float in
+          ( OR <newinstname>.speed_in  float in  )
+
+
+   Speed command input
+
+   gearchange.N.speed_out  float out
+          ( OR <newinstname>.speed_out  float out  )
+
+
+   Speed command to DAC/PWM
+
+   gearchange.N.dir_in  bit in
+          ( OR <newinstname>.dir_in  bit in  )
+
+
+   Direction command input
+
+   gearchange.N.dir_out  bit out
+          ( OR <newinstname>.dir_out  bit out  )
+
+
+   Direction output - possibly inverted for second gear
+
+   gearchange.N.min1  float io (default: 0.0)
+          ( OR <newinstname>.min1  float io (default: 0.0) )
+
+
+   Minimum allowed speed in gear range 1
+
+   gearchange.N.max1  float io (default: 100000)
+          ( OR <newinstname>.max1  float io (default: 100000) )
+
+
+   Maximum allowed speed in gear range 1
+
+   gearchange.N.min2  float io (default: 0.0)
+          ( OR <newinstname>.min2  float io (default: 0.0) )
+
+
+   Minimum allowed speed in gear range 2
+
+   gearchange.N.max2  float io (default: 100000)
+          ( OR <newinstname>.max2  float io (default: 100000) )
+
+
+   Maximum allowed speed in gear range 2
+
+   gearchange.N.scale2  float io (default: 1.0)
+          ( OR <newinstname>.scale2  float io (default: 1.0) )
+
+
+   Relative scale of gear 2 vs. gear 1 Since it is assumed that gear 2 is "high gear", scale2 must be greater than 1, and will be reset to 1 if set lower.
+
+   gearchange.N.reverse  bit io (default: 0.0)
+          ( OR <newinstname>.reverse  bit io (default: 0.0) )
+
+
+   Set to 1 to reverse the spindle in second gear
+----------------------------------------------------------------------------------------------------------------------------------------------------------
+
+LICENSE
+
+------
+   GPL
+------
+
+Machinekit Documentation 2015-11-01 GEARCHANGE(9)

--- a/machinekit-documentation/components/gray2bin.asciidoc
+++ b/machinekit-documentation/components/gray2bin.asciidoc
@@ -1,0 +1,79 @@
+GRAY2BIN(9) HAL Component GRAY2BIN(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+-------------------------------------------------
+   gray2bin - convert a gray-code input to binary
+-------------------------------------------------
+
+SYNOPSIS
+
+-----------
+   gray2bin
+-----------
+
+USAGE SYNOPSIS
+
+----------------------------------------------------------------------------------------------
+   loadrt gray2bin
+
+   newinst gray2bin <newinstname> [ pincount=N | iprefix=prefix ] [instanceparamX=X | argX=X ]
+----------------------------------------------------------------------------------------------
+
+DESCRIPTION
+
+-------------------------------------------------------------------
+   Converts a gray-coded number into the corresponding binary value
+-------------------------------------------------------------------
+
+FUNCTIONS
+
+-------------------------------------
+   gray2bin.N.funct
+          ( OR <newinstname>.funct  )
+-------------------------------------
+
+PINS
+
+--------------------------------------------
+   gray2bin.N.in  u32 in
+          ( OR <newinstname>.in  u32 in  )
+
+
+   gray code in
+
+   gray2bin.N.out  u32 out
+          ( OR <newinstname>.out  u32 out  )
+
+
+   binary code out
+--------------------------------------------
+
+AUTHOR
+
+------------
+   andy pugh
+------------
+
+LICENSE
+
+------
+   GPL
+------
+
+Machinekit Documentation 2015-11-01 GRAY2BIN(9)

--- a/machinekit-documentation/components/hbridge.asciidoc
+++ b/machinekit-documentation/components/hbridge.asciidoc
@@ -1,0 +1,107 @@
+HBRIDGE(9) HAL Component HBRIDGE(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+-------------------------------------------------------------------------------
+   hbridge - generate driving signals for 2 PWM generators to drive an H-Bridge
+-------------------------------------------------------------------------------
+
+SYNOPSIS
+
+----------
+   hbridge
+----------
+
+USAGE SYNOPSIS
+
+---------------------------------------------------------------------------------------------
+   loadrt hbridge
+
+   newinst hbridge <newinstname> [ pincount=N | iprefix=prefix ] [instanceparamX=X | argX=X ]
+---------------------------------------------------------------------------------------------
+
+DESCRIPTION
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+          Together  with 2 PWM's, this comp can be used to drive a DC motor through an H-bridge.  If the H-bridge needs a PWM signal at full speed (e.g. for charge pumps), limit the output value by set‐
+          ting maxout.  See also: http://en.wikipedia.org/wiki/H_bridge .
+
+          Two output pins, up and down. For positive inputs, the PWM/PDM driving signal appears on up, while down is low. For negative inputs, the driving signal on down, while up is low.  Suitable  for
+          driving the two sides of an H-bridge to generate a bipolar output.
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+FUNCTIONS
+
+-----------------------------------------------------------------------
+   hbridge.N.funct
+          ( OR <newinstname>.funct (requires a floating-point thread) )
+-----------------------------------------------------------------------
+
+PINS
+
+--------------------------------------------------------------
+   hbridge.N.command  float in
+          ( OR <newinstname>.command  float in  )
+
+
+   target speed, < 0: reverse, > 0: forward
+
+   hbridge.N.down  float out
+          ( OR <newinstname>.down  float out  )
+
+
+   driving value for PWM1, 0..maxout
+
+   hbridge.N.up  float out
+          ( OR <newinstname>.up  float out  )
+
+
+   driving value for PWM2, 0..maxout
+
+   hbridge.N.enable-out  bit out
+          ( OR <newinstname>.enable-out  bit out  )
+
+
+   output to enable both half-bridges
+
+   hbridge.N.enable  bit in
+          ( OR <newinstname>.enable  bit in  )
+
+
+   let motor free run if false
+
+   hbridge.N.brake  bit in
+          ( OR <newinstname>.brake  bit in  )
+
+
+   brake motor if true; needs enable to be true
+
+   hbridge.N.maxout  float io (default: 1.0)
+          ( OR <newinstname>.maxout  float io (default: 1.0) )
+
+
+   limit for the up and down pins
+--------------------------------------------------------------
+
+LICENSE
+
+---------
+   GPL v2
+---------
+
+Machinekit Documentation 2015-11-01 HBRIDGE(9)

--- a/machinekit-documentation/components/hypot.asciidoc
+++ b/machinekit-documentation/components/hypot.asciidoc
@@ -1,0 +1,73 @@
+HYPOT(9) HAL Component HYPOT(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+-----------------------------------------------------------------
+   hypot - Three-input hypotenuse (Euclidean distance) calculator
+-----------------------------------------------------------------
+
+SYNOPSIS
+
+--------
+   hypot
+--------
+
+USAGE SYNOPSIS
+
+-------------------------------------------------------------------------------------------
+   loadrt hypot
+
+   newinst hypot <newinstname> [ pincount=N | iprefix=prefix ] [instanceparamX=X | argX=X ]
+-------------------------------------------------------------------------------------------
+
+FUNCTIONS
+
+-----------------------------------------------------------------------
+   hypot.N.funct
+          ( OR <newinstname>.funct (requires a floating-point thread) )
+-----------------------------------------------------------------------
+
+PINS
+
+----------------------------------------------
+   hypot.N.in0  float in
+          ( OR <newinstname>.in0  float in  )
+
+
+   hypot.N.in1  float in
+          ( OR <newinstname>.in1  float in  )
+
+
+   hypot.N.in2  float in
+          ( OR <newinstname>.in2  float in  )
+
+
+   hypot.N.out  float out
+          ( OR <newinstname>.out  float out  )
+
+
+   out = sqrt(in0^2 + in1^2 + in2^2)
+----------------------------------------------
+
+LICENSE
+
+------
+   GPL
+------
+
+Machinekit Documentation 2015-11-01 HYPOT(9)

--- a/machinekit-documentation/components/idb.asciidoc
+++ b/machinekit-documentation/components/idb.asciidoc
@@ -1,0 +1,76 @@
+IDB(9) HAL Component IDB(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+-------------------------
+   idb - Inverse Deadband
+-------------------------
+
+SYNOPSIS
+
+------
+   idb
+------
+
+USAGE SYNOPSIS
+
+-----------------------------------------------------------------------------------------
+   loadrt idb
+
+   newinst idb <newinstname> [ pincount=N | iprefix=prefix ] [instanceparamX=X | argX=X ]
+-----------------------------------------------------------------------------------------
+
+FUNCTIONS
+
+-----------------------------------------------------------------------
+   idb.N.funct
+          ( OR <newinstname>.funct (requires a floating-point thread) )
+-----------------------------------------------------------------------
+
+PINS
+
+------------------------------------------------
+   idb.N.in  float in
+          ( OR <newinstname>.in  float in  )
+
+
+   Input
+
+   idb.N.out  float out
+          ( OR <newinstname>.out  float out  )
+
+
+   Output
+
+   idb.N.amount  float io
+          ( OR <newinstname>.amount  float io  )
+------------------------------------------------
+
+AUTHOR
+
+----------------
+   Anders Wallin
+----------------
+
+LICENSE
+
+------
+   GPL
+------
+
+Machinekit Documentation 2015-11-01 IDB(9)

--- a/machinekit-documentation/components/ilowpass.asciidoc
+++ b/machinekit-documentation/components/ilowpass.asciidoc
@@ -1,0 +1,98 @@
+ILOWPASS(9) HAL Component ILOWPASS(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+-------------------------------------------------------------
+   ilowpass - Low-pass filter with integer inputs and outputs
+-------------------------------------------------------------
+
+SYNOPSIS
+
+-----------
+   ilowpass
+-----------
+
+USAGE SYNOPSIS
+
+----------------------------------------------------------------------------------------------
+   loadrt ilowpass
+
+   newinst ilowpass <newinstname> [ pincount=N | iprefix=prefix ] [instanceparamX=X | argX=X ]
+----------------------------------------------------------------------------------------------
+
+DESCRIPTION
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+   While it may find other applications, this component was written to create smoother motion while jogging with an MPG.
+
+          In a machine with high acceleration, a short jog can behave almost like a step function.  By putting the ilowpass component between the MPG encoder counts output and the axis jog-counts input,
+          this can be smoothed.
+
+          Choose scale conservatively so that during a single session there will never be more than about 2e9/scale pulses seen on the MPG.  Choose gain according to the smoothing level desired.  Divide
+          the axis.N.jog-scale values by scale.
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+FUNCTIONS
+
+-----------------------------------------------------------------------
+   ilowpass.N.funct
+          ( OR <newinstname>.funct (requires a floating-point thread) )
+
+   Update the output based on the input and parameters
+-----------------------------------------------------------------------
+
+PINS
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+   ilowpass.N.in  s32 in
+          ( OR <newinstname>.in  s32 in  )
+
+
+   ilowpass.N.out  s32 out
+          ( OR <newinstname>.out  s32 out  )
+
+
+   out tracks in*scale through a low-pass filter of gain per period.
+
+   ilowpass.N.scale  float io (default: 1024.0)
+          ( OR <newinstname>.scale  float io (default: 1024.0) )
+
+
+   A scale factor applied to the output value of the low-pass filter.
+
+   ilowpass.N.gain  float io (default: 0.5)
+          ( OR <newinstname>.gain  float io (default: 0.5) )
+
+
+   Together  with the period, sets the rate at which the output changes.  Useful range is between 0 and 1, with higher values causing the input value to be tracked more quickly.  For instance, a setting
+          of 0.9 causes the output value to go 90% of the way towards the input value in each period
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+AUTHOR
+
+-------------------------------------
+   Jeff Epler <jepler@unpythonic.net>
+-------------------------------------
+
+LICENSE
+
+------
+   GPL
+------
+
+Machinekit Documentation 2015-11-01 ILOWPASS(9)

--- a/machinekit-documentation/components/integ.asciidoc
+++ b/machinekit-documentation/components/integ.asciidoc
@@ -1,0 +1,82 @@
+INTEG(9) HAL Component INTEG(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+-----------------------------------------------------
+   integ - Integrator with gain pin and windup limits
+-----------------------------------------------------
+
+SYNOPSIS
+
+--------
+   integ
+--------
+
+USAGE SYNOPSIS
+
+-------------------------------------------------------------------------------------------
+   loadrt integ
+
+   newinst integ <newinstname> [ pincount=N | iprefix=prefix ] [instanceparamX=X | argX=X ]
+-------------------------------------------------------------------------------------------
+
+FUNCTIONS
+
+-----------------------------------------------------------------------
+   integ.N.funct
+          ( OR <newinstname>.funct (requires a floating-point thread) )
+-----------------------------------------------------------------------
+
+PINS
+
+--------------------------------------------------------------------
+   integ.N.in  float in
+          ( OR <newinstname>.in  float in  )
+
+
+   integ.N.gain  float in (default: 1.0)
+          ( OR <newinstname>.gain  float in (default: 1.0) )
+
+
+   integ.N.out  float out
+          ( OR <newinstname>.out  float out  )
+
+
+   The discrete integral of 'gain * in' since 'reset' was deasserted
+
+   integ.N.reset  bit in
+          ( OR <newinstname>.reset  bit in  )
+
+
+   When asserted, set out to 0
+
+   integ.N.max_  float in (default: 1e20)
+          ( OR <newinstname>.max_  float in (default: 1e20) )
+
+
+   integ.N.min_  float in (default: -1e20)
+          ( OR <newinstname>.min_  float in (default: -1e20) )
+--------------------------------------------------------------------
+
+LICENSE
+
+------
+   GPL
+------
+
+Machinekit Documentation 2015-11-01 INTEG(9)

--- a/machinekit-documentation/components/invert.asciidoc
+++ b/machinekit-documentation/components/invert.asciidoc
@@ -1,0 +1,73 @@
+INVERT(9) HAL Component INVERT(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+---------------------------------------------------
+   invert - Compute the inverse of the input signal
+---------------------------------------------------
+
+SYNOPSIS
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+   The output will be the mathematical inverse of the input, ie out = 1/in.  The parameter deadband can be used to control how close to 0 the denominator can be before the output is clamped to 0.  dead‐
+          band must be at least 1e-8, and must be positive.
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+USAGE SYNOPSIS
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+   The output will be the mathematical inverse of the input, ie out = 1/in.  The parameter deadband can be used to control how close to 0 the denominator can be before the output is clamped to 0.  dead‐
+          band must be at least 1e-8, and must be positive.
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+FUNCTIONS
+
+-----------------------------------------------------------------------
+   invert.N.funct
+          ( OR <newinstname>.funct (requires a floating-point thread) )
+-----------------------------------------------------------------------
+
+PINS
+
+----------------------------------------------------------------
+   invert.N.in  float in
+          ( OR <newinstname>.in  float in  )
+
+
+   Analog input value
+
+   invert.N.out  float out
+          ( OR <newinstname>.out  float out  )
+
+
+   Analog output value
+
+   invert.N.deadband  float io
+          ( OR <newinstname>.deadband  float io  )
+
+
+   The out will be zero if in is between -deadband and +deadband
+----------------------------------------------------------------
+
+LICENSE
+
+------
+   GPL
+------
+
+Machinekit Documentation 2015-11-01 INVERT(9)

--- a/machinekit-documentation/components/io_muxn.asciidoc
+++ b/machinekit-documentation/components/io_muxn.asciidoc
@@ -1,0 +1,80 @@
+IO_MUXN(9) HAL Component IO_MUXN(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+---------------------------------------
+   io_muxn - Gate one of N input values
+---------------------------------------
+
+SYNOPSIS
+
+----------
+   io_muxn
+----------
+
+USAGE SYNOPSIS
+
+---------------------------------------------------------------------------------------------
+   loadrt io_muxn
+
+   newinst io_muxn <newinstname> [ pincount=N | iprefix=prefix ] [instanceparamX=X | argX=X ]
+---------------------------------------------------------------------------------------------
+
+FUNCTIONS
+
+-----------------------------------------------------------------------
+   io_muxn.N.funct
+          ( OR <newinstname>.funct (requires a floating-point thread) )
+-----------------------------------------------------------------------
+
+PINS
+
+----------------------------------------------------------------------------------------------------------------------------------
+   io_muxn.N.sel  s32 in (default: 0)
+          ( OR <newinstname>.sel  s32 in (default: 0) )
+
+
+   io_muxn.N.out  float io
+          ( OR <newinstname>.out  float io  )
+
+
+   Follows the value of in<M> whereas M is the value of the sel input. If sel is not in the range of available inputs 0 is output.
+
+   io_muxn.N.in#.  float io (M=0..pincount)
+          ( OR <newinstname>.in#.  float io (M=0..pincount)  )
+----------------------------------------------------------------------------------------------------------------------------------
+
+INST_PARAMETERS
+
+----------------------------
+   pincount int (default: 2)
+----------------------------
+
+AUTHOR
+
+---------------------
+   Alexander Roessler
+---------------------
+
+LICENSE
+
+------
+   GPL
+------
+
+Machinekit Documentation 2015-11-01 IO_MUXN(9)

--- a/machinekit-documentation/components/joyhandle.asciidoc
+++ b/machinekit-documentation/components/joyhandle.asciidoc
@@ -1,0 +1,105 @@
+JOYHANDLE(9) HAL Component JOYHANDLE(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+--------------------------------------------------------------------
+   joyhandle - sets nonlinear joypad movements, deadbands and scales
+--------------------------------------------------------------------
+
+SYNOPSIS
+
+------------
+   joyhandle
+------------
+
+USAGE SYNOPSIS
+
+-----------------------------------------------------------------------------------------------
+   loadrt joyhandle
+
+   newinst joyhandle <newinstname> [ pincount=N | iprefix=prefix ] [instanceparamX=X | argX=X ]
+-----------------------------------------------------------------------------------------------
+
+DESCRIPTION
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+          The component joyhandle uses the following formula for a non linear joypad movements:
+
+          y = (scale * (a*x^power + b*x)) + offset
+
+          The parameters a and b are adjusted in such a way, that the function starts at (deadband,offset) and ends at (1,scale+offset).
+
+          Negative values will be treated point symetrically to origin. Values -deadband < x < +deadband will be set to zero.
+
+          Values x > 1 and x < -1 will be skipped to ±(scale+offset). Invert transforms the function to a progressive movement.
+
+          With power one can adjust the nonlinearity (default = 2). Default for deadband is 0.
+
+          Valid  values  are:  power >= 1.0 (reasonable values are 1.x .. 4-5, take higher power-values for higher deadbands (>0.5), if you want to start with a nearly horizontal slope), 0 <= deadband <
+          0.99 (reasonable 0.1).
+
+          An additional offset component can be set in special cases (default = 0).
+
+          All values can be adjusted for each instance separately.
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+FUNCTIONS
+
+-----------------------------------------------------------------------
+   joyhandle.N.funct
+          ( OR <newinstname>.funct (requires a floating-point thread) )
+-----------------------------------------------------------------------
+
+PINS
+
+----------------------------------------------------------------
+   joyhandle.N.in  float in
+          ( OR <newinstname>.in  float in  )
+
+
+   joyhandle.N.out  float out
+          ( OR <newinstname>.out  float out  )
+
+
+   joyhandle.N.power  float io (default: 2.0)
+          ( OR <newinstname>.power  float io (default: 2.0) )
+
+
+   joyhandle.N.deadband  float io (default: 0.0)
+          ( OR <newinstname>.deadband  float io (default: 0.0) )
+
+
+   joyhandle.N.scale  float io (default: 1.0)
+          ( OR <newinstname>.scale  float io (default: 1.0) )
+
+
+   joyhandle.N.offset  float io (default: 0.0)
+          ( OR <newinstname>.offset  float io (default: 0.0) )
+
+
+   joyhandle.N.inverse  bit io (default: false)
+          ( OR <newinstname>.inverse  bit io (default: false) )
+----------------------------------------------------------------
+
+LICENSE
+
+------
+   GPL
+------
+
+Machinekit Documentation 2015-11-01 JOYHANDLE(9)

--- a/machinekit-documentation/components/knob2float.asciidoc
+++ b/machinekit-documentation/components/knob2float.asciidoc
@@ -1,0 +1,91 @@
+KNOB2FLOAT(9) HAL Component KNOB2FLOAT(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+--------------------------------------------------------------------------
+   knob2float - Convert counts (probably from an encoder) to a float value
+--------------------------------------------------------------------------
+
+SYNOPSIS
+
+-------------
+   knob2float
+-------------
+
+USAGE SYNOPSIS
+
+------------------------------------------------------------------------------------------------
+   loadrt knob2float
+
+   newinst knob2float <newinstname> [ pincount=N | iprefix=prefix ] [instanceparamX=X | argX=X ]
+------------------------------------------------------------------------------------------------
+
+FUNCTIONS
+
+-----------------------------------------------------------------------
+   knob2float.N.funct
+          ( OR <newinstname>.funct (requires a floating-point thread) )
+-----------------------------------------------------------------------
+
+PINS
+
+------------------------------------------------------------------------
+   knob2float.N.counts  s32 in
+          ( OR <newinstname>.counts  s32 in  )
+
+
+   Counts
+
+   knob2float.N.enable  bit in
+          ( OR <newinstname>.enable  bit in  )
+
+
+   When TRUE, output is controlled by count, when FALSE, output is fixed
+
+   knob2float.N.scale  float in
+          ( OR <newinstname>.scale  float in  )
+
+
+   Amount of output change per count
+
+   knob2float.N.out  float out
+          ( OR <newinstname>.out  float out  )
+
+
+   Output value
+
+   knob2float.N.max_out  float io (default: 1.0)
+          ( OR <newinstname>.max_out  float io (default: 1.0) )
+
+
+   Maximum output value, further increases in count will be ignored
+
+   knob2float.N.min_out  float io (default: 0.0)
+          ( OR <newinstname>.min_out  float io (default: 0.0) )
+
+
+   Minimum output value, further decreases in count will be ignored
+------------------------------------------------------------------------
+
+LICENSE
+
+------
+   GPL
+------
+
+Machinekit Documentation 2015-11-01 KNOB2FLOAT(9)

--- a/machinekit-documentation/components/latencybins.asciidoc
+++ b/machinekit-documentation/components/latencybins.asciidoc
@@ -1,0 +1,142 @@
+LATENCYBINS(9) HAL Component LATENCYBINS(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+----------------------------------------------------------
+   latencybins - comp utility for scripts/latencyhistogram
+----------------------------------------------------------
+
+SYNOPSIS
+
+--------------------------------------------------------------------------
+          Usage:
+            Read availablebins pin for the number of bins available.
+            Set the maxbinnumber pin for the number of +/- bins.
+              Ensure maxbinnumber <= availablebins
+              For maxbinnumber = N, the bins are numbered:
+                 -N ... 0 ... + N bins
+              (the -0 bin is not populated)
+              (total effective bins = 2*maxbinnumber +1)
+            Set nsbinsize pin for the binsize (ns)
+            Iterate:
+              Set index pin to a bin number: 0 <= index <= maxbinnumber.
+              Read check pin and verify that check pin == index pin.
+              Read pbinvalue,nbinvalue,pextra,nextra pins.
+                   (pbinvalue is count for bin = +index)
+                   (nbinvalue is count for bin = -index)
+                   (pextra    is count for all bins > maxbinnumber)
+                   (nextra    is count for all bins < maxbinnumber)
+
+             If index is out of range ( index < 0 or index > maxbinnumber)
+             then pbinvalue = nbinvalue = -1.
+             The reset pin may be used to restart.
+             The latency pin outputs the instantaneous latency.
+
+          Maintainers note: hardcoded for MAXBINNUMBER==1000
+--------------------------------------------------------------------------
+
+USAGE SYNOPSIS
+
+--------------------------------------------------------------------------
+          Usage:
+            Read availablebins pin for the number of bins available.
+            Set the maxbinnumber pin for the number of +/- bins.
+              Ensure maxbinnumber <= availablebins
+              For maxbinnumber = N, the bins are numbered:
+                 -N ... 0 ... + N bins
+              (the -0 bin is not populated)
+              (total effective bins = 2*maxbinnumber +1)
+            Set nsbinsize pin for the binsize (ns)
+            Iterate:
+              Set index pin to a bin number: 0 <= index <= maxbinnumber.
+              Read check pin and verify that check pin == index pin.
+              Read pbinvalue,nbinvalue,pextra,nextra pins.
+                   (pbinvalue is count for bin = +index)
+                   (nbinvalue is count for bin = -index)
+                   (pextra    is count for all bins > maxbinnumber)
+                   (nextra    is count for all bins < maxbinnumber)
+
+             If index is out of range ( index < 0 or index > maxbinnumber)
+             then pbinvalue = nbinvalue = -1.
+             The reset pin may be used to restart.
+             The latency pin outputs the instantaneous latency.
+
+          Maintainers note: hardcoded for MAXBINNUMBER==1000
+--------------------------------------------------------------------------
+
+FUNCTIONS
+
+-------------------------------------
+   latencybins.N.funct
+          ( OR <newinstname>.funct  )
+-------------------------------------
+
+PINS
+
+---------------------------------------------------------------------
+   latencybins.N.maxbinnumber  s32 in (default: 1000)
+          ( OR <newinstname>.maxbinnumber  s32 in (default: 1000) )
+
+
+   latencybins.N.index  s32 in
+          ( OR <newinstname>.index  s32 in  )
+
+
+   latencybins.N.reset  bit in
+          ( OR <newinstname>.reset  bit in  )
+
+
+   latencybins.N.nsbinsize  s32 in
+          ( OR <newinstname>.nsbinsize  s32 in  )
+
+
+   latencybins.N.check  s32 out
+          ( OR <newinstname>.check  s32 out  )
+
+
+   latencybins.N.latency  s32 out
+          ( OR <newinstname>.latency  s32 out  )
+
+
+   latencybins.N.pbinvalue  s32 out
+          ( OR <newinstname>.pbinvalue  s32 out  )
+
+
+   latencybins.N.nbinvalue  s32 out
+          ( OR <newinstname>.nbinvalue  s32 out  )
+
+
+   latencybins.N.pextra  s32 out
+          ( OR <newinstname>.pextra  s32 out  )
+
+
+   latencybins.N.nextra  s32 out
+          ( OR <newinstname>.nextra  s32 out  )
+
+
+   latencybins.N.availablebins  s32 out (default: 1000)
+          ( OR <newinstname>.availablebins  s32 out (default: 1000) )
+---------------------------------------------------------------------
+
+LICENSE
+
+------
+   GPL
+------
+
+Machinekit Documentation 2015-11-01 LATENCYBINS(9)

--- a/machinekit-documentation/components/led_dim.asciidoc
+++ b/machinekit-documentation/components/led_dim.asciidoc
@@ -1,0 +1,77 @@
+LED_DIM(9) HAL Component LED_DIM(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+----------------------------------------------------
+   led_dim - LinuxCNC HAL component for dimming LEDs
+----------------------------------------------------
+
+SYNOPSIS
+
+----------
+   led_dim
+----------
+
+USAGE SYNOPSIS
+
+---------------------------------------------------------------------------------------------
+   loadrt led_dim
+
+   newinst led_dim <newinstname> [ pincount=N | iprefix=prefix ] [instanceparamX=X | argX=X ]
+---------------------------------------------------------------------------------------------
+
+DESCRIPTION
+
+-----------------------------------------------------------------------------------------
+          Component for LED dimming according to human perception of brightness of light.
+
+   The output is calculated using the CIE 1931 formula.
+-----------------------------------------------------------------------------------------
+
+FUNCTIONS
+
+-----------------------------------------------------------------------
+   led_dim.N.funct
+          ( OR <newinstname>.funct (requires a floating-point thread) )
+
+   Update the output value
+-----------------------------------------------------------------------
+
+PINS
+
+----------------------------------------------
+   led_dim.N.in  float in
+          ( OR <newinstname>.in  float in  )
+
+
+   Brightness input value -> 0 to 1
+
+   led_dim.N.out  float out
+          ( OR <newinstname>.out  float out  )
+
+
+   Luminance output value -> 0 to 1
+----------------------------------------------
+
+LICENSE
+
+------
+   GPL
+------
+
+Machinekit Documentation 2015-11-01 LED_DIM(9)

--- a/machinekit-documentation/components/lgantry.asciidoc
+++ b/machinekit-documentation/components/lgantry.asciidoc
@@ -1,0 +1,156 @@
+LGANTRY(9) HAL Component LGANTRY(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+------------------------------------------------------------------------------------
+   lgantry - Machinekit HAL component for driving multiple joints from a single axis
+------------------------------------------------------------------------------------
+
+SYNOPSIS
+
+----------
+   lgantry
+----------
+
+USAGE SYNOPSIS
+
+---------------------------------------------------------------------------------------------
+   loadrt lgantry
+
+   newinst lgantry <newinstname> [ pincount=N | iprefix=prefix ] [instanceparamX=X | argX=X ]
+---------------------------------------------------------------------------------------------
+
+DESCRIPTION
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+          Drives multiple physical motors (joints) from a single axis input
+
+   The `pincount' value is the number of joints to control.  Two is typical, but up to seven is supported (a three joint setup has been tested with hardware).
+
+   All  controlled  joints  track the commanded position (with a per-joint offset) unless in the process of latching.  Latching is when the commanded position is moving away the from the homing switches
+   (as determined by the sign of search-vel), the joint home switches are not all in the same state and homing is active.  When the system is latching and a joint home switch  deactivates,  the  command
+   value sent to that joint is "frozen" and the joint offset value is updated instead.  Once all home switches are deactivated, there are no more adjustments made to the offset values and all joints run
+   in lock-step once more.
+
+   For best results, set HOME_SEARCH_VEL and HOME_LATCH_VEL to the opposite direction and as slow as practical.  When a joint home switch  trips,  the  commanded  velocity  will  drop  immediately  from
+   HOME_SEARCH_VEL to zero, with no limit on accleration.
+
+   The latching gantry component is the opposite of the normal gantry component. It makes sense to use it with home switches that have a reproduceable deactivation hysteresis.
+
+   Using the per joint home-offset input it is possible add a small offset when latching.  This makes it possible to adjust small differences in the endstop positions of the gantry setup.
+
+   The homing input must be connected to the axis homing output motion in order to enable the gantry component. When the axis is not homing latching will not be activated.
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+FUNCTIONS
+
+-----------------------------------------------------------------------------
+   lgantry.N.read.funct
+          ( OR <newinstname>.read.funct (requires a floating-point thread) )
+
+   Update position-fb and home/limit outputs based on joint values
+
+   lgantry.N.write.funct
+          ( OR <newinstname>.write.funct (requires a floating-point thread) )
+
+   Update joint pos-cmd outputs based on position-cmd in
+-----------------------------------------------------------------------------
+
+PINS
+
+--------------------------------------------------------------------------------
+   lgantry.N.joint.##.pos-cmd  float out (MM=00..pincount)
+          ( OR <newinstname>.joint.##.pos-cmd  float out (MM=00..pincount)  )
+
+
+   Per-joint commanded position
+
+   lgantry.N.joint.##.pos-fb  float in (MM=00..pincount)
+          ( OR <newinstname>.joint.##.pos-fb  float in (MM=00..pincount)  )
+
+
+   Per-joint position feedback
+
+   lgantry.N.joint.##.home  bit in (MM=00..pincount)
+          ( OR <newinstname>.joint.##.home  bit in (MM=00..pincount)  )
+
+
+   Per-joint home switch
+
+   lgantry.N.joint.##.home-offset  float in (MM=00..pincount)
+          ( OR <newinstname>.joint.##.home-offset  float in (MM=00..pincount)  )
+
+
+   Per-joint home offset for fine tuning
+
+   lgantry.N.joint.##.offset  float out (MM=00..pincount)
+          ( OR <newinstname>.joint.##.offset  float out (MM=00..pincount)  )
+
+
+   (debugging) Per-joint offset value, updated when homing
+
+   lgantry.N.position-cmd  float in
+          ( OR <newinstname>.position-cmd  float in  )
+
+
+   Commanded position from motion
+
+   lgantry.N.position-fb  float out
+          ( OR <newinstname>.position-fb  float out  )
+
+
+   Position feedback to motion
+
+   lgantry.N.homing  bit in
+          ( OR <newinstname>.homing  bit in  )
+
+
+   Axis homing state from motion
+
+   lgantry.N.home  bit out
+          ( OR <newinstname>.home  bit out  )
+
+
+   Combined home signal, true if all joint home inputs are true
+
+   lgantry.N.limit  bit out
+          ( OR <newinstname>.limit  bit out  )
+
+
+   Combined limit signal, true if any joint home input is true
+
+   lgantry.N.search-vel  float in
+          ( OR <newinstname>.search-vel  float in  )
+
+
+   HOME_SEARCH_VEL from ini file
+--------------------------------------------------------------------------------
+
+INST_PARAMETERS
+
+----------------------------
+   pincount int (default: 7)
+----------------------------
+
+LICENSE
+
+------
+   GPL
+------
+
+Machinekit Documentation 2015-11-01 LGANTRY(9)

--- a/machinekit-documentation/components/limit1.asciidoc
+++ b/machinekit-documentation/components/limit1.asciidoc
@@ -1,0 +1,70 @@
+LIMIT1(9) HAL Component LIMIT1(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+---------------------------------------------------------------
+   limit1 - Limit the output signal to fall between min and max
+---------------------------------------------------------------
+
+SYNOPSIS
+
+---------
+   limit1
+---------
+
+USAGE SYNOPSIS
+
+--------------------------------------------------------------------------------------------
+   loadrt limit1
+
+   newinst limit1 <newinstname> [ pincount=N | iprefix=prefix ] [instanceparamX=X | argX=X ]
+--------------------------------------------------------------------------------------------
+
+FUNCTIONS
+
+-----------------------------------------------------------------------
+   limit1.N.funct
+          ( OR <newinstname>.funct (requires a floating-point thread) )
+-----------------------------------------------------------------------
+
+PINS
+
+--------------------------------------------------------------
+   limit1.N.in  float in
+          ( OR <newinstname>.in  float in  )
+
+
+   limit1.N.out  float out
+          ( OR <newinstname>.out  float out  )
+
+
+   limit1.N.min_  float in (default: -1e20)
+          ( OR <newinstname>.min_  float in (default: -1e20) )
+
+
+   limit1.N.max_  float in (default: 1e20)
+          ( OR <newinstname>.max_  float in (default: 1e20) )
+--------------------------------------------------------------
+
+LICENSE
+
+------
+   GPL
+------
+
+Machinekit Documentation 2015-11-01 LIMIT1(9)

--- a/machinekit-documentation/components/limit2.asciidoc
+++ b/machinekit-documentation/components/limit2.asciidoc
@@ -1,0 +1,80 @@
+LIMIT2(9) HAL Component LIMIT2(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+   limit2 - Limit the output signal to fall between min and max and limit its slew rate to less than maxv per second.  When the signal is a position, this means that position and velocity are limited.
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+SYNOPSIS
+
+---------
+   limit2
+---------
+
+USAGE SYNOPSIS
+
+--------------------------------------------------------------------------------------------
+   loadrt limit2
+
+   newinst limit2 <newinstname> [ pincount=N | iprefix=prefix ] [instanceparamX=X | argX=X ]
+--------------------------------------------------------------------------------------------
+
+FUNCTIONS
+
+-----------------------------------------------------------------------
+   limit2.N.funct
+          ( OR <newinstname>.funct (requires a floating-point thread) )
+-----------------------------------------------------------------------
+
+PINS
+
+--------------------------------------------------------------
+   limit2.N.in  float in
+          ( OR <newinstname>.in  float in  )
+
+
+   limit2.N.out  float out
+          ( OR <newinstname>.out  float out  )
+
+
+   limit2.N.load  bit in
+          ( OR <newinstname>.load  bit in  )
+
+
+   When TRUE, immediately set out to in, ignoring maxv
+
+   limit2.N.min_  float io (default: -1e20)
+          ( OR <newinstname>.min_  float io (default: -1e20) )
+
+
+   limit2.N.max_  float io (default: 1e20)
+          ( OR <newinstname>.max_  float io (default: 1e20) )
+
+
+   limit2.N.maxv  float io (default: 1e20)
+          ( OR <newinstname>.maxv  float io (default: 1e20) )
+--------------------------------------------------------------
+
+LICENSE
+
+------
+   GPL
+------
+
+Machinekit Documentation 2015-11-01 LIMIT2(9)

--- a/machinekit-documentation/components/limit3.asciidoc
+++ b/machinekit-documentation/components/limit3.asciidoc
@@ -1,0 +1,85 @@
+LIMIT3(9) HAL Component LIMIT3(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+   limit3  - Limit the output signal to fall between min and max, limit its slew rate to less than maxv per second, and limit its second derivative to less than maxa per second squared.  When the signal
+          is a position, this means that the position, velocity, and acceleration are limited.
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+SYNOPSIS
+
+---------
+   limit3
+---------
+
+USAGE SYNOPSIS
+
+--------------------------------------------------------------------------------------------
+   loadrt limit3
+
+   newinst limit3 <newinstname> [ pincount=N | iprefix=prefix ] [instanceparamX=X | argX=X ]
+--------------------------------------------------------------------------------------------
+
+FUNCTIONS
+
+-----------------------------------------------------------------------
+   limit3.N.funct
+          ( OR <newinstname>.funct (requires a floating-point thread) )
+-----------------------------------------------------------------------
+
+PINS
+
+---------------------------------------------------------------
+   limit3.N.in  float in
+          ( OR <newinstname>.in  float in  )
+
+
+   limit3.N.out  float out
+          ( OR <newinstname>.out  float out  )
+
+
+   limit3.N.load  bit in
+          ( OR <newinstname>.load  bit in  )
+
+
+   When TRUE, immediately set out to in, ignoring maxv and maxa
+
+   limit3.N.min_  float in (default: -1e20)
+          ( OR <newinstname>.min_  float in (default: -1e20) )
+
+
+   limit3.N.max_  float in (default: 1e20)
+          ( OR <newinstname>.max_  float in (default: 1e20) )
+
+
+   limit3.N.maxv  float in (default: 1e20)
+          ( OR <newinstname>.maxv  float in (default: 1e20) )
+
+
+   limit3.N.maxa  float in (default: 1e20)
+          ( OR <newinstname>.maxa  float in (default: 1e20) )
+---------------------------------------------------------------
+
+LICENSE
+
+------
+   GPL
+------
+
+Machinekit Documentation 2015-11-01 LIMIT3(9)

--- a/machinekit-documentation/components/lincurve.asciidoc
+++ b/machinekit-documentation/components/lincurve.asciidoc
@@ -1,0 +1,111 @@
+LINCURVE(9) HAL Component LINCURVE(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+------------------------------------------
+   lincurve - one-dimensional lookup table
+------------------------------------------
+
+SYNOPSIS
+
+-----------
+   lincurve
+-----------
+
+USAGE SYNOPSIS
+
+----------------------------------------------------------------------------------------------
+   loadrt lincurve
+
+   newinst lincurve <newinstname> [ pincount=N | iprefix=prefix ] [instanceparamX=X | argX=X ]
+----------------------------------------------------------------------------------------------
+
+DESCRIPTION
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+   Performs a 1-dimensional lookup and interpolation. The x-val parameters must be monotonic, though identical adjacent values are allowed.  (for example 0,0,0,10) for a 4-element curve.
+
+          For  input values less than the x-val-00 breakpoint the y-val-00 is returned.  For x greater than the largest x-val-NN the yval corresponding to x-max is returned (ie, no extrapolation is per‐
+          formed.)
+
+          Sample usage: loadrt lincurve-inst
+                        newinst lincurve newone pincount=4 iprefix=lincurve4 for a 4-element curve.
+
+          The axis breakpoints should be set in the lincurve.x-val-NN parameters using "setp", as should the corresponding y values.
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+FUNCTIONS
+
+-----------------------------------------------------------------------
+   lincurve.N.funct
+          ( OR <newinstname>.funct (requires a floating-point thread) )
+-----------------------------------------------------------------------
+
+PINS
+
+--------------------------------------------------------------------
+   lincurve.N.x-val-##  float io (MM=00..pincount)
+          ( OR <newinstname>.x-val-##  float io (MM=00..pincount)  )
+
+
+   axis breakpoints
+
+   lincurve.N.y-val-##  float io (MM=00..pincount)
+          ( OR <newinstname>.y-val-##  float io (MM=00..pincount)  )
+
+
+   output values to be interpolated
+
+   lincurve.N.in_  float in
+          ( OR <newinstname>.in_  float in  )
+
+
+   The input value
+
+   lincurve.N.out_  float out
+          ( OR <newinstname>.out_  float out  )
+
+
+   The output value
+
+   lincurve.N.out-io  float io
+          ( OR <newinstname>.out-io  float io  )
+
+
+   The output value, compatible with PID gains
+--------------------------------------------------------------------
+
+INST_PARAMETERS
+
+----------------------------
+   pincount int (default: 4)
+----------------------------
+
+AUTHOR
+
+------------
+   Andy Pugh
+------------
+
+LICENSE
+
+------
+   GPL
+------
+
+Machinekit Documentation 2015-11-01 LINCURVE(9)

--- a/machinekit-documentation/components/lowpass.asciidoc
+++ b/machinekit-documentation/components/lowpass.asciidoc
@@ -1,0 +1,81 @@
+LOWPASS(9) HAL Component LOWPASS(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+----------------------------
+   lowpass - Low-pass filter
+----------------------------
+
+SYNOPSIS
+
+----------
+   lowpass
+----------
+
+USAGE SYNOPSIS
+
+---------------------------------------------------------------------------------------------
+   loadrt lowpass
+
+   newinst lowpass <newinstname> [ pincount=N | iprefix=prefix ] [instanceparamX=X | argX=X ]
+---------------------------------------------------------------------------------------------
+
+FUNCTIONS
+
+-----------------------------------------------------------------------
+   lowpass.N.funct
+          ( OR <newinstname>.funct (requires a floating-point thread) )
+-----------------------------------------------------------------------
+
+PINS
+
+---------------------------------------------------------------------
+   lowpass.N.in  float in
+          ( OR <newinstname>.in  float in  )
+
+
+   lowpass.N.out  float out
+          ( OR <newinstname>.out  float out  )
+
+
+
+           out += (in - out) * gain
+
+   lowpass.N.load  bit in
+          ( OR <newinstname>.load  bit in  )
+
+
+   When TRUE, copy in to out instead of applying the filter equation.
+
+   lowpass.N.gain  float in
+          ( OR <newinstname>.gain  float in  )
+---------------------------------------------------------------------
+
+NOTES
+
+------------------------------------------------------------------------------------------------------------
+   The effect of a specific gain value is dependent on the period of the function that lowpass.N is added to
+------------------------------------------------------------------------------------------------------------
+
+LICENSE
+
+------
+   GPL
+------
+
+Machinekit Documentation 2015-11-01 LOWPASS(9)

--- a/machinekit-documentation/components/lut5.asciidoc
+++ b/machinekit-documentation/components/lut5.asciidoc
@@ -1,0 +1,146 @@
+LUT5(9) HAL Component LUT5(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+-------------------------------------------------------------------
+   lut5 - Arbitrary 5-input logic function based on a look-up table
+-------------------------------------------------------------------
+
+SYNOPSIS
+
+-------
+   lut5
+-------
+
+USAGE SYNOPSIS
+
+------------------------------------------------------------------------------------------
+   loadrt lut5
+
+   newinst lut5 <newinstname> [ pincount=N | iprefix=prefix ] [instanceparamX=X | argX=X ]
+------------------------------------------------------------------------------------------
+
+DESCRIPTION
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+          lut5  constructs  a  logic function with up to 5 inputs using a look-up table. The value for function can be determined by writing the truth table, and computing the sum of all the weights for
+          which the output value would be true.  The weights are hexadecimal not decimal so hexadecimal math must be used to sum the weights. A wiki page has a calculator  to  assist  in  computing  the
+          proper value for function.
+
+   http://wiki.linuxcnc.org/cgi-bin/wiki.pl?Lut5
+
+   Note that LUT5 will generate any of the 4,294,967,296 logical functions of 5 inputs so AND, OR, NAND, NOR, XOR and every other combinatorial function is possible.
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+Example Functions A 5-input and function is true only when all the
+inputs are true, so the correct value for function is 0x80000000.
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+   A 2-input or function would be the sum of 0x2 + 0x4 + 0x8, so the correct value for function is 0xe.
+
+   A  5-input  or  function  is  true  whenever any of the inputs are true, so the correct value for function is 0xfffffffe. Because every weight except 0x1 is true the function is the sum of every line
+   except the first one.
+
+   A 2-input xor function is true whenever exactly one of the inputs is true, so the correct value for function is 0x6.  Only in-0 and in-1 should be connected to signals, because if any  other  bit  is
+   true then the output will be false.
+
+   ┌───────────────────────────────────────────────────┐
+   │       Weights for each line of truth table        │
+   ├──────────────────────────────────────┬────────────┤
+   │Bit 4   Bit 3   Bit 2   Bit 1   Bit 0 │   Weight   │
+   ├──────────────────────────────────────┼────────────┤
+   │  0       0       0       0       0   │        0x1 │
+   │  0       0       0       0       1   │        0x2 │
+   │  0       0       0       1       0   │        0x4 │
+   │  0       0       0       1       1   │        0x8 │
+   │  0       0       1       0       0   │       0x10 │
+   │  0       0       1       0       1   │       0x20 │
+   │  0       0       1       1       0   │       0x40 │
+   │  0       0       1       1       1   │       0x80 │
+   │  0       1       0       0       0   │      0x100 │
+   │  0       1       0       0       1   │      0x200 │
+   │  0       1       0       1       0   │      0x400 │
+   │  0       1       0       1       1   │      0x800 │
+   │  0       1       1       0       0   │     0x1000 │
+   │  0       1       1       0       1   │     0x2000 │
+   │  0       1       1       1       0   │     0x4000 │
+   │  0       1       1       1       1   │     0x8000 │
+   │  1       0       0       0       0   │    0x10000 │
+   │  1       0       0       0       1   │    0x20000 │
+   │  1       0       0       1       0   │    0x40000 │
+   │  1       0       0       1       1   │    0x80000 │
+   │  1       0       1       0       0   │   0x100000 │
+   │  1       0       1       0       1   │   0x200000 │
+   │  1       0       1       1       0   │   0x400000 │
+   │  1       0       1       1       1   │   0x800000 │
+   │  1       1       0       0       0   │  0x1000000 │
+   │  1       1       0       0       1   │  0x2000000 │
+   │  1       1       0       1       0   │  0x4000000 │
+   │  1       1       0       1       1   │  0x8000000 │
+   │  1       1       1       0       0   │ 0x10000000 │
+   │  1       1       1       0       1   │ 0x20000000 │
+   │  1       1       1       1       0   │ 0x40000000 │
+   │  1       1       1       1       1   │ 0x80000000 │
+   └──────────────────────────────────────┴────────────┘
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+FUNCTIONS
+
+-------------------------------------
+   lut5.N.funct
+          ( OR <newinstname>.funct  )
+-------------------------------------
+
+PINS
+
+------------------------------------------------
+   lut5.N.in_0  bit in
+          ( OR <newinstname>.in_0  bit in  )
+
+
+   lut5.N.in_1  bit in
+          ( OR <newinstname>.in_1  bit in  )
+
+
+   lut5.N.in_2  bit in
+          ( OR <newinstname>.in_2  bit in  )
+
+
+   lut5.N.in_3  bit in
+          ( OR <newinstname>.in_3  bit in  )
+
+
+   lut5.N.in_4  bit in
+          ( OR <newinstname>.in_4  bit in  )
+
+
+   lut5.N.out  bit out
+          ( OR <newinstname>.out  bit out  )
+
+
+   lut5.N.function  u32 io
+          ( OR <newinstname>.function  u32 io  )
+------------------------------------------------
+
+LICENSE
+
+------
+   GPL
+------
+
+Machinekit Documentation 2015-11-01 LUT5(9)

--- a/machinekit-documentation/components/lutn.asciidoc
+++ b/machinekit-documentation/components/lutn.asciidoc
@@ -1,0 +1,69 @@
+LUTN(9) HAL Component LUTN(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+-------
+   lutn
+-------
+
+SYNOPSIS
+
+-------
+   lutn
+-------
+
+USAGE SYNOPSIS
+
+------------------------------------------------------------------------------------------
+   loadrt lutn
+
+   newinst lutn <newinstname> [ pincount=N | iprefix=prefix ] [instanceparamX=X | argX=X ]
+------------------------------------------------------------------------------------------
+
+FUNCTIONS
+
+-----------------------------------------------------------------------
+   lutn.N.funct
+          ( OR <newinstname>.funct (requires a floating-point thread) )
+-----------------------------------------------------------------------
+
+PINS
+
+---------------------------------------------------------------
+   lutn.N.in-##  bit in (MM=00..pincount)
+          ( OR <newinstname>.in-##  bit in (MM=00..pincount)  )
+
+
+   lutn.N.out  bit out
+          ( OR <newinstname>.out  bit out  )
+---------------------------------------------------------------
+
+INST_PARAMETERS
+
+----------------------------
+   pincount int (default: 2)
+   functn int (default: 0)
+----------------------------
+
+LICENSE
+
+------
+   GPL
+------
+
+Machinekit Documentation 2015-11-01 LUTN(9)

--- a/machinekit-documentation/components/maj3.asciidoc
+++ b/machinekit-documentation/components/maj3.asciidoc
@@ -1,0 +1,74 @@
+MAJ3(9) HAL Component MAJ3(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+------------------------------------------
+   maj3 - Compute the majority of 3 inputs
+------------------------------------------
+
+SYNOPSIS
+
+-------
+   maj3
+-------
+
+USAGE SYNOPSIS
+
+------------------------------------------------------------------------------------------
+   loadrt maj3
+
+   newinst maj3 <newinstname> [ pincount=N | iprefix=prefix ] [instanceparamX=X | argX=X ]
+------------------------------------------------------------------------------------------
+
+FUNCTIONS
+
+-------------------------------------
+   maj3.N.funct
+          ( OR <newinstname>.funct  )
+-------------------------------------
+
+PINS
+
+----------------------------------------------
+   maj3.N.in1  bit in
+          ( OR <newinstname>.in1  bit in  )
+
+
+   maj3.N.in2  bit in
+          ( OR <newinstname>.in2  bit in  )
+
+
+   maj3.N.in3  bit in
+          ( OR <newinstname>.in3  bit in  )
+
+
+   maj3.N.out  bit out
+          ( OR <newinstname>.out  bit out  )
+
+
+   maj3.N.invert  bit io
+          ( OR <newinstname>.invert  bit io  )
+----------------------------------------------
+
+LICENSE
+
+------
+   GPL
+------
+
+Machinekit Documentation 2015-11-01 MAJ3(9)

--- a/machinekit-documentation/components/match8.asciidoc
+++ b/machinekit-documentation/components/match8.asciidoc
@@ -1,0 +1,131 @@
+MATCH8(9) HAL Component MATCH8(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+---------------------------------------
+   match8 - 8-bit binary match detector
+---------------------------------------
+
+SYNOPSIS
+
+---------
+   match8
+---------
+
+USAGE SYNOPSIS
+
+--------------------------------------------------------------------------------------------
+   loadrt match8
+
+   newinst match8 <newinstname> [ pincount=N | iprefix=prefix ] [instanceparamX=X | argX=X ]
+--------------------------------------------------------------------------------------------
+
+FUNCTIONS
+
+-------------------------------------
+   match8.N.funct
+          ( OR <newinstname>.funct  )
+-------------------------------------
+
+PINS
+
+-----------------------------------------------------------------------
+   match8.N.in  bit in (default: true)
+          ( OR <newinstname>.in  bit in (default: true) )
+
+
+   cascade input - if false, output is false regardless of other inputs
+
+   match8.N.a0  bit in
+          ( OR <newinstname>.a0  bit in  )
+
+
+   match8.N.a1  bit in
+          ( OR <newinstname>.a1  bit in  )
+
+
+   match8.N.a2  bit in
+          ( OR <newinstname>.a2  bit in  )
+
+
+   match8.N.a3  bit in
+          ( OR <newinstname>.a3  bit in  )
+
+
+   match8.N.a4  bit in
+          ( OR <newinstname>.a4  bit in  )
+
+
+   match8.N.a5  bit in
+          ( OR <newinstname>.a5  bit in  )
+
+
+   match8.N.a6  bit in
+          ( OR <newinstname>.a6  bit in  )
+
+
+   match8.N.a7  bit in
+          ( OR <newinstname>.a7  bit in  )
+
+
+   match8.N.b0  bit in
+          ( OR <newinstname>.b0  bit in  )
+
+
+   match8.N.b1  bit in
+          ( OR <newinstname>.b1  bit in  )
+
+
+   match8.N.b2  bit in
+          ( OR <newinstname>.b2  bit in  )
+
+
+   match8.N.b3  bit in
+          ( OR <newinstname>.b3  bit in  )
+
+
+   match8.N.b4  bit in
+          ( OR <newinstname>.b4  bit in  )
+
+
+   match8.N.b5  bit in
+          ( OR <newinstname>.b5  bit in  )
+
+
+   match8.N.b6  bit in
+          ( OR <newinstname>.b6  bit in  )
+
+
+   match8.N.b7  bit in
+          ( OR <newinstname>.b7  bit in  )
+
+
+   match8.N.out  bit out
+          ( OR <newinstname>.out  bit out  )
+
+
+   true only if in is true and a[m] matches b[m] for m = 0 thru 7
+-----------------------------------------------------------------------
+
+LICENSE
+
+------
+   GPL
+------
+
+Machinekit Documentation 2015-11-01 MATCH8(9)

--- a/machinekit-documentation/components/minmax.asciidoc
+++ b/machinekit-documentation/components/minmax.asciidoc
@@ -1,0 +1,72 @@
+MINMAX(9) HAL Component MINMAX(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+----------------------------------------------------------------------------
+   minmax - Track the minimum and maximum values of the input to the outputs
+----------------------------------------------------------------------------
+
+SYNOPSIS
+
+---------
+   minmax
+---------
+
+USAGE SYNOPSIS
+
+--------------------------------------------------------------------------------------------
+   loadrt minmax
+
+   newinst minmax <newinstname> [ pincount=N | iprefix=prefix ] [instanceparamX=X | argX=X ]
+--------------------------------------------------------------------------------------------
+
+FUNCTIONS
+
+-----------------------------------------------------------------------
+   minmax.N.funct
+          ( OR <newinstname>.funct (requires a floating-point thread) )
+-----------------------------------------------------------------------
+
+PINS
+
+--------------------------------------------------------
+   minmax.N.in  float in
+          ( OR <newinstname>.in  float in  )
+
+
+   minmax.N.reset  bit in
+          ( OR <newinstname>.reset  bit in  )
+
+
+   When reset is asserted, 'in' is copied to the outputs
+
+   minmax.N.max_  float out
+          ( OR <newinstname>.max_  float out  )
+
+
+   minmax.N.min_  float out
+          ( OR <newinstname>.min_  float out  )
+--------------------------------------------------------
+
+LICENSE
+
+------
+   GPL
+------
+
+Machinekit Documentation 2015-11-01 MINMAX(9)

--- a/machinekit-documentation/components/mult2.asciidoc
+++ b/machinekit-documentation/components/mult2.asciidoc
@@ -1,0 +1,69 @@
+MULT2(9) HAL Component MULT2(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+--------------------------------
+   mult2 - Product of two inputs
+--------------------------------
+
+SYNOPSIS
+
+--------
+   mult2
+--------
+
+USAGE SYNOPSIS
+
+-------------------------------------------------------------------------------------------
+   loadrt mult2
+
+   newinst mult2 <newinstname> [ pincount=N | iprefix=prefix ] [instanceparamX=X | argX=X ]
+-------------------------------------------------------------------------------------------
+
+FUNCTIONS
+
+-----------------------------------------------------------------------
+   mult2.N.funct
+          ( OR <newinstname>.funct (requires a floating-point thread) )
+-----------------------------------------------------------------------
+
+PINS
+
+----------------------------------------------
+   mult2.N.in0  float in
+          ( OR <newinstname>.in0  float in  )
+
+
+   mult2.N.in1  float in
+          ( OR <newinstname>.in1  float in  )
+
+
+   mult2.N.out  float out
+          ( OR <newinstname>.out  float out  )
+
+
+   out = in0 * in1
+----------------------------------------------
+
+LICENSE
+
+------
+   GPL
+------
+
+Machinekit Documentation 2015-11-01 MULT2(9)

--- a/machinekit-documentation/components/multiclick.asciidoc
+++ b/machinekit-documentation/components/multiclick.asciidoc
@@ -1,0 +1,156 @@
+MULTICLICK(9) HAL Component MULTICLICK(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+-----------------------------------------------------------------------
+   multiclick - Single-, double-, triple-, and quadruple-click detector
+-----------------------------------------------------------------------
+
+SYNOPSIS
+
+-------------
+   multiclick
+-------------
+
+USAGE SYNOPSIS
+
+------------------------------------------------------------------------------------------------
+   loadrt multiclick
+
+   newinst multiclick <newinstname> [ pincount=N | iprefix=prefix ] [instanceparamX=X | argX=X ]
+------------------------------------------------------------------------------------------------
+
+DESCRIPTION
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+   A click is defined as a rising edge on the 'in' pin, followed by the 'in' pin being True for at most 'max-hold-ns' nanoseconds, followed by a falling edge.
+
+          A double-click is defined as two clicks, separated by at most 'max-space-ns' nanoseconds with the 'in' pin in the False state.
+
+          I bet you can guess the definition of triple- and quadruple-click.
+
+          You probably want to run the input signal through a debounce component before feeding it to the multiclick detector, if the input is at all noisy.
+
+          The '*-click' pins go high as soon as the input detects the correct number of clicks.
+
+          The '*-click-only' pins go high a short while after the click, after the click separator space timeout has expired to show that no further click is coming.  This is useful for triggering halui
+          MDI commands.
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+FUNCTIONS
+
+---------------------------------------------------------
+   multiclick.N.funct
+          ( OR <newinstname>.funct  )
+
+   Detect single-, double-, triple-, and quadruple-clicks
+---------------------------------------------------------
+
+PINS
+
+-----------------------------------------------------------------------------------------------------------------
+   multiclick.N.in  bit in
+          ( OR <newinstname>.in  bit in  )
+
+
+   The input line, this is where we look for clicks.
+
+   multiclick.N.single_click  bit out
+          ( OR <newinstname>.single_click  bit out  )
+
+
+   Goes high briefly when a single-click is detected on the 'in' pin.
+
+   multiclick.N.single_click_only  bit out
+          ( OR <newinstname>.single_click_only  bit out  )
+
+
+   Goes high briefly when a single-click is detected on the 'in' pin and no second click followed it.
+
+   multiclick.N.double_click  bit out
+          ( OR <newinstname>.double_click  bit out  )
+
+
+   Goes high briefly when a double-click is detected on the 'in' pin.
+
+   multiclick.N.double_click_only  bit out
+          ( OR <newinstname>.double_click_only  bit out  )
+
+
+   Goes high briefly when a double-click is detected on the 'in' pin and no third click followed it.
+
+   multiclick.N.triple_click  bit out
+          ( OR <newinstname>.triple_click  bit out  )
+
+
+   Goes high briefly when a triple-click is detected on the 'in' pin.
+
+   multiclick.N.triple_click_only  bit out
+          ( OR <newinstname>.triple_click_only  bit out  )
+
+
+   Goes high briefly when a triple-click is detected on the 'in' pin and no fourth click followed it.
+
+   multiclick.N.quadruple_click  bit out
+          ( OR <newinstname>.quadruple_click  bit out  )
+
+
+   Goes high briefly when a quadruple-click is detected on the 'in' pin.
+
+   multiclick.N.quadruple_click_only  bit out
+          ( OR <newinstname>.quadruple_click_only  bit out  )
+
+
+   Goes high briefly when a quadruple-click is detected on the 'in' pin and no fifth click followed it.
+
+   multiclick.N.state  s32 out
+          ( OR <newinstname>.state  s32 out  )
+
+
+   multiclick.N.invert_input  bit io (default: false)
+          ( OR <newinstname>.invert_input  bit io (default: false) )
+
+
+   If false (the default), clicks start with rising edges.  If true, clicks start with falling edges.
+
+   multiclick.N.max_hold_ns  u32 io (default: 250000000)
+          ( OR <newinstname>.max_hold_ns  u32 io (default: 250000000) )
+
+
+   If the input is held down longer than this, it's not part of a multi-click.  (Default 250,000,000 ns, 250 ms.)
+
+   multiclick.N.max_space_ns  u32 io (default: 250000000)
+          ( OR <newinstname>.max_space_ns  u32 io (default: 250000000) )
+
+
+   If the input is released longer than this, it's not part of a multi-click.  (Default 250,000,000 ns, 250 ms.)
+
+   multiclick.N.output_hold_ns  u32 io (default: 100000000)
+          ( OR <newinstname>.output_hold_ns  u32 io (default: 100000000) )
+
+
+   Positive pulses on the output pins last this long.  (Default 100,000,000 ns, 100 ms.)
+-----------------------------------------------------------------------------------------------------------------
+
+LICENSE
+
+------
+   GPL
+------
+
+Machinekit Documentation 2015-11-01 MULTICLICK(9)

--- a/machinekit-documentation/components/multiswitch.asciidoc
+++ b/machinekit-documentation/components/multiswitch.asciidoc
@@ -1,0 +1,97 @@
+MULTISWITCH(9) HAL Component MULTISWITCH(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+---------------------------------------------------------------------------------
+   multiswitch - This component toggles between a specified number of output bits
+---------------------------------------------------------------------------------
+
+SYNOPSIS
+
+--------------
+   multiswitch
+--------------
+
+USAGE SYNOPSIS
+
+-------------------------------------------------------------------------------------------------
+   loadrt multiswitch
+
+   newinst multiswitch <newinstname> [ pincount=N | iprefix=prefix ] [instanceparamX=X | argX=X ]
+-------------------------------------------------------------------------------------------------
+
+FUNCTIONS
+
+-----------------------------------------------------------------------
+   multiswitch.N.funct
+          ( OR <newinstname>.funct (requires a floating-point thread) )
+-----------------------------------------------------------------------
+
+PINS
+
+---------------------------------------------------------------------------------
+   multiswitch.N.up  bit in (default: false)
+          ( OR <newinstname>.up  bit in (default: false) )
+
+
+   Receives signal to toggle up
+
+   multiswitch.N.down  bit in (default: false)
+          ( OR <newinstname>.down  bit in (default: false) )
+
+
+   Receives signal to toggle down
+
+   multiswitch.N.top-position  u32 io
+          ( OR <newinstname>.top-position  u32 io  )
+
+
+   Number of positions
+
+   multiswitch.N.position  s32 io
+          ( OR <newinstname>.position  s32 io  )
+
+
+   Current state (may be set in the HAL)
+
+   multiswitch.N.bit-##  bit out (MM=00..pincount) (default: false)
+          ( OR <newinstname>.bit-##  bit out (MM=00..pincount) (default: false) )
+
+
+   Output bits
+---------------------------------------------------------------------------------
+
+INST_PARAMETERS
+
+----------------------------
+   pincount int (default: 6)
+----------------------------
+
+AUTHOR
+
+-----------------------------------------------------------
+   ArcEye arceye@mgware.co.uk / Andy Pugh andy@bodgesoc.org
+-----------------------------------------------------------
+
+LICENSE
+
+-------
+   GPL2
+-------
+
+Machinekit Documentation 2015-11-01 MULTISWITCH(9)

--- a/machinekit-documentation/components/mux16.asciidoc
+++ b/machinekit-documentation/components/mux16.asciidoc
@@ -1,0 +1,124 @@
+MUX16(9) HAL Component MUX16(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+--------------------------------------------------
+   mux16 - Select from one of sixteen input values
+--------------------------------------------------
+
+SYNOPSIS
+
+--------
+   mux16
+--------
+
+USAGE SYNOPSIS
+
+-------------------------------------------------------------------------------------------
+   loadrt mux16
+
+   newinst mux16 <newinstname> [ pincount=N | iprefix=prefix ] [instanceparamX=X | argX=X ]
+-------------------------------------------------------------------------------------------
+
+DESCRIPTION
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+   pin  in  bit  use_graycode  This  signifies  the  input will use Gray code instead of binary.  Gray code is a good choice when using physical switches because for each increment only one select input
+          changes at a time.
+
+          pin in bit suppress_no_input This suppresses changing the output if all select lines are false.  This stops unwanted jumps in output between transitions of input.  but make in00 unavaliable.
+
+          pin in float debounce_time sets debouce time in seconds.  eg. .10 = a tenth of a second input must be stable this long before outputs changes. This helps to ignore 'noisy' switches.
+
+          pin in bit sel#[4] Together, these determine which inN value is copied to out.
+
+          pin out float out_f pin out s32 out_s Follows the value of one of the inN values according to the four sel values and whether use-graycode is active.
+
+          The s32 value will be trunuated and limited to the max and min values of signed values.
+
+          sel3=false, sel2=false, sel1=false, sel0=false
+                 out follows in0
+
+          sel3=false, sel2=false, sel1=false, sel0=true
+                 out follows in1
+
+          etc.
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+FUNCTIONS
+
+-----------------------------------------------------------------------
+   mux16.N.funct
+          ( OR <newinstname>.funct (requires a floating-point thread) )
+-----------------------------------------------------------------------
+
+PINS
+
+--------------------------------------------------------------------
+   mux16.N.use_graycode  bit in
+          ( OR <newinstname>.use_graycode  bit in  )
+
+
+   mux16.N.suppress_no_input  bit in
+          ( OR <newinstname>.suppress_no_input  bit in  )
+
+
+   mux16.N.debounce_time  float in
+          ( OR <newinstname>.debounce_time  float in  )
+
+
+   mux16.N.sel#  bit in (M=0..4)
+          ( OR <newinstname>.sel#  bit in (M=0..4)  )
+
+
+   mux16.N.out_f  float out
+          ( OR <newinstname>.out_f  float out  )
+
+
+   mux16.N.out_s  s32 out
+          ( OR <newinstname>.out_s  s32 out  )
+
+
+   mux16.N.elapsed  float out
+          ( OR <newinstname>.elapsed  float out  )
+
+
+   Current value of the internal debounce timer
+           for debugging.
+
+   mux16.N.selected  s32 out
+          ( OR <newinstname>.selected  s32 out  )
+
+
+   Current value of the internal selection variable after conversion
+           for debugging
+
+   mux16.N.in##  float in (MM=00..16)
+          ( OR <newinstname>.in##  float in (MM=00..16)  )
+
+
+   array of selectable outputs
+--------------------------------------------------------------------
+
+LICENSE
+
+------
+   GPL
+------
+
+Machinekit Documentation 2015-11-01 MUX16(9)

--- a/machinekit-documentation/components/mux2.asciidoc
+++ b/machinekit-documentation/components/mux2.asciidoc
@@ -1,0 +1,72 @@
+MUX2(9) HAL Component MUX2(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+---------------------------------------------
+   mux2 - Select from one of two input values
+---------------------------------------------
+
+SYNOPSIS
+
+-------
+   mux2
+-------
+
+USAGE SYNOPSIS
+
+------------------------------------------------------------------------------------------
+   loadrt mux2
+
+   newinst mux2 <newinstname> [ pincount=N | iprefix=prefix ] [instanceparamX=X | argX=X ]
+------------------------------------------------------------------------------------------
+
+FUNCTIONS
+
+-----------------------------------------------------------------------
+   mux2.N.funct
+          ( OR <newinstname>.funct (requires a floating-point thread) )
+-----------------------------------------------------------------------
+
+PINS
+
+------------------------------------------------------------------
+   mux2.N.sel  bit in
+          ( OR <newinstname>.sel  bit in  )
+
+
+   mux2.N.out  float out
+          ( OR <newinstname>.out  float out  )
+
+
+   Follows the value of in0 if sel is FALSE, or in1 if sel is TRUE
+
+   mux2.N.in1  float in
+          ( OR <newinstname>.in1  float in  )
+
+
+   mux2.N.in0  float in
+          ( OR <newinstname>.in0  float in  )
+------------------------------------------------------------------
+
+LICENSE
+
+------
+   GPL
+------
+
+Machinekit Documentation 2015-11-01 MUX2(9)

--- a/machinekit-documentation/components/mux4.asciidoc
+++ b/machinekit-documentation/components/mux4.asciidoc
@@ -1,0 +1,100 @@
+MUX4(9) HAL Component MUX4(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+----------------------------------------------
+   mux4 - Select from one of four input values
+----------------------------------------------
+
+SYNOPSIS
+
+-------
+   mux4
+-------
+
+USAGE SYNOPSIS
+
+------------------------------------------------------------------------------------------
+   loadrt mux4
+
+   newinst mux4 <newinstname> [ pincount=N | iprefix=prefix ] [instanceparamX=X | argX=X ]
+------------------------------------------------------------------------------------------
+
+FUNCTIONS
+
+-----------------------------------------------------------------------
+   mux4.N.funct
+          ( OR <newinstname>.funct (requires a floating-point thread) )
+-----------------------------------------------------------------------
+
+PINS
+
+-----------------------------------------------------------------------------
+   mux4.N.sel0  bit in
+          ( OR <newinstname>.sel0  bit in  )
+
+
+   mux4.N.sel1  bit in
+          ( OR <newinstname>.sel1  bit in  )
+
+
+   Together, these determine which inN value is copied to out.
+
+
+   mux4.N.out  float out
+          ( OR <newinstname>.out  float out  )
+
+
+   Follows the value of one of the inN values according to the two sel values
+
+          sel1=FALSE, sel0=FALSE
+                 out follows in0
+
+          sel1=FALSE, sel0=TRUE
+                 out follows in1
+
+          sel1=TRUE, sel0=FALSE
+                 out follows in2
+
+          sel1=TRUE, sel0=TRUE
+                 out follows in3
+
+
+   mux4.N.in0  float in
+          ( OR <newinstname>.in0  float in  )
+
+
+   mux4.N.in1  float in
+          ( OR <newinstname>.in1  float in  )
+
+
+   mux4.N.in2  float in
+          ( OR <newinstname>.in2  float in  )
+
+
+   mux4.N.in3  float in
+          ( OR <newinstname>.in3  float in  )
+-----------------------------------------------------------------------------
+
+LICENSE
+
+------
+   GPL
+------
+
+Machinekit Documentation 2015-11-01 MUX4(9)

--- a/machinekit-documentation/components/mux8.asciidoc
+++ b/machinekit-documentation/components/mux8.asciidoc
@@ -1,0 +1,132 @@
+MUX8(9) HAL Component MUX8(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+-----------------------------------------------
+   mux8 - Select from one of eight input values
+-----------------------------------------------
+
+SYNOPSIS
+
+-------
+   mux8
+-------
+
+USAGE SYNOPSIS
+
+------------------------------------------------------------------------------------------
+   loadrt mux8
+
+   newinst mux8 <newinstname> [ pincount=N | iprefix=prefix ] [instanceparamX=X | argX=X ]
+------------------------------------------------------------------------------------------
+
+FUNCTIONS
+
+-----------------------------------------------------------------------
+   mux8.N.funct
+          ( OR <newinstname>.funct (requires a floating-point thread) )
+-----------------------------------------------------------------------
+
+PINS
+
+-------------------------------------------------------------------------------
+   mux8.N.sel0  bit in
+          ( OR <newinstname>.sel0  bit in  )
+
+
+   mux8.N.sel1  bit in
+          ( OR <newinstname>.sel1  bit in  )
+
+
+   mux8.N.sel2  bit in
+          ( OR <newinstname>.sel2  bit in  )
+
+
+   Together, these determine which inN value is copied to out.
+
+
+   mux8.N.out  float out
+          ( OR <newinstname>.out  float out  )
+
+
+   Follows the value of one of the inN values according to the three sel values
+
+          sel2=FALSE, sel1=FALSE, sel0=FALSE
+                 out follows in0
+
+          sel2=FALSE, sel1=FALSE, sel0=TRUE
+                 out follows in1
+
+          sel2=FALSE, sel1=TRUE, sel0=FALSE
+                 out follows in2
+
+          sel2=FALSE, sel1=TRUE, sel0=TRUE
+                 out follows in3
+
+          sel2=TRUE, sel1=FALSE, sel0=FALSE
+                 out follows in4
+
+          sel2=TRUE, sel1=FALSE, sel0=TRUE
+                 out follows in5
+
+          sel2=TRUE, sel1=TRUE, sel0=FALSE
+                 out follows in6
+
+          sel2=TRUE, sel1=TRUE, sel0=TRUE
+                 out follows in7
+
+
+   mux8.N.in0  float in
+          ( OR <newinstname>.in0  float in  )
+
+
+   mux8.N.in1  float in
+          ( OR <newinstname>.in1  float in  )
+
+
+   mux8.N.in2  float in
+          ( OR <newinstname>.in2  float in  )
+
+
+   mux8.N.in3  float in
+          ( OR <newinstname>.in3  float in  )
+
+
+   mux8.N.in4  float in
+          ( OR <newinstname>.in4  float in  )
+
+
+   mux8.N.in5  float in
+          ( OR <newinstname>.in5  float in  )
+
+
+   mux8.N.in6  float in
+          ( OR <newinstname>.in6  float in  )
+
+
+   mux8.N.in7  float in
+          ( OR <newinstname>.in7  float in  )
+-------------------------------------------------------------------------------
+
+LICENSE
+
+------
+   GPL
+------
+
+Machinekit Documentation 2015-11-01 MUX8(9)

--- a/machinekit-documentation/components/muxn.asciidoc
+++ b/machinekit-documentation/components/muxn.asciidoc
@@ -1,0 +1,80 @@
+MUXN(9) HAL Component MUXN(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+-------------------------------------------
+   muxn - Select from one of N input values
+-------------------------------------------
+
+SYNOPSIS
+
+-------
+   muxn
+-------
+
+USAGE SYNOPSIS
+
+------------------------------------------------------------------------------------------
+   loadrt muxn
+
+   newinst muxn <newinstname> [ pincount=N | iprefix=prefix ] [instanceparamX=X | argX=X ]
+------------------------------------------------------------------------------------------
+
+FUNCTIONS
+
+-----------------------------------------------------------------------
+   muxn.N.funct
+          ( OR <newinstname>.funct (requires a floating-point thread) )
+-----------------------------------------------------------------------
+
+PINS
+
+----------------------------------------------------------------------------------------------------------------------------------
+   muxn.N.sel  s32 in (default: 0)
+          ( OR <newinstname>.sel  s32 in (default: 0) )
+
+
+   muxn.N.out  float out
+          ( OR <newinstname>.out  float out  )
+
+
+   Follows the value of in<M> whereas M is the value of the sel input. If sel is not in the range of available inputs 0 is output.
+
+   muxn.N.in#.  float in (M=0..pincount)
+          ( OR <newinstname>.in#.  float in (M=0..pincount)  )
+----------------------------------------------------------------------------------------------------------------------------------
+
+INST_PARAMETERS
+
+----------------------------
+   pincount int (default: 2)
+----------------------------
+
+AUTHOR
+
+---------------------
+   Alexander Roessler
+---------------------
+
+LICENSE
+
+------
+   GPL
+------
+
+Machinekit Documentation 2015-11-01 MUXN(9)

--- a/machinekit-documentation/components/muxn_u32.asciidoc
+++ b/machinekit-documentation/components/muxn_u32.asciidoc
@@ -1,0 +1,80 @@
+MUXN_U32(9) HAL Component MUXN_U32(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+----------------------------------------------------
+   muxn_u32 - Select from one of N input values, U32
+----------------------------------------------------
+
+SYNOPSIS
+
+-----------
+   muxn_u32
+-----------
+
+USAGE SYNOPSIS
+
+----------------------------------------------------------------------------------------------
+   loadrt muxn_u32
+
+   newinst muxn_u32 <newinstname> [ pincount=N | iprefix=prefix ] [instanceparamX=X | argX=X ]
+----------------------------------------------------------------------------------------------
+
+FUNCTIONS
+
+-----------------------------------------------------------------------
+   muxn_u32.N.funct
+          ( OR <newinstname>.funct (requires a floating-point thread) )
+-----------------------------------------------------------------------
+
+PINS
+
+----------------------------------------------------------------------------------------------------------------------------------
+   muxn_u32.N.sel  s32 in (default: 0)
+          ( OR <newinstname>.sel  s32 in (default: 0) )
+
+
+   muxn_u32.N.out  u32 out
+          ( OR <newinstname>.out  u32 out  )
+
+
+   Follows the value of in<M> whereas M is the value of the sel input. If sel is not in the range of available inputs 0 is output.
+
+   muxn_u32.N.in#.  u32 in (M=0..pincount)
+          ( OR <newinstname>.in#.  u32 in (M=0..pincount)  )
+----------------------------------------------------------------------------------------------------------------------------------
+
+INST_PARAMETERS
+
+----------------------------
+   pincount int (default: 2)
+----------------------------
+
+AUTHOR
+
+---------------------
+   Alexander Roessler
+---------------------
+
+LICENSE
+
+------
+   GPL
+------
+
+Machinekit Documentation 2015-11-01 MUXN_U32(9)

--- a/machinekit-documentation/components/near.asciidoc
+++ b/machinekit-documentation/components/near.asciidoc
@@ -1,0 +1,80 @@
+NEAR(9) HAL Component NEAR(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+---------------------------------------------------------
+   near - Determine whether two values are roughly equal.
+---------------------------------------------------------
+
+SYNOPSIS
+
+-------
+   near
+-------
+
+USAGE SYNOPSIS
+
+------------------------------------------------------------------------------------------
+   loadrt near
+
+   newinst near <newinstname> [ pincount=N | iprefix=prefix ] [instanceparamX=X | argX=X ]
+------------------------------------------------------------------------------------------
+
+FUNCTIONS
+
+-----------------------------------------------------------------------
+   near.N.funct
+          ( OR <newinstname>.funct (requires a floating-point thread) )
+-----------------------------------------------------------------------
+
+PINS
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+   near.N.in1_  float in
+          ( OR <newinstname>.in1_  float in  )
+
+
+   near.N.in2_  float in
+          ( OR <newinstname>.in2_  float in  )
+
+
+   near.N.scale  float io (default: 1.0)
+          ( OR <newinstname>.scale  float io (default: 1.0) )
+
+
+   near.N.difference  float io (default: 0.0)
+          ( OR <newinstname>.difference  float io (default: 0.0) )
+
+
+   near.N.out  bit out
+          ( OR <newinstname>.out  bit out  )
+
+
+
+
+          out  is true if in1 and in2 are within a factor of scale (i.e., for in1 positive, in1/scale <= in2 <= in1*scale), OR if their absolute difference is no greater than difference (i.e., |in1-in2|
+          <= difference).  out is false otherwise.
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+LICENSE
+
+------
+   GPL
+------
+
+Machinekit Documentation 2015-11-01 NEAR(9)

--- a/machinekit-documentation/components/neg.asciidoc
+++ b/machinekit-documentation/components/neg.asciidoc
@@ -1,0 +1,62 @@
+NEG(9) HAL Component NEG(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+---------------------------------------------------
+   neg - Changes the sign of a floating point value
+---------------------------------------------------
+
+SYNOPSIS
+
+------
+   neg
+------
+
+USAGE SYNOPSIS
+
+-----------------------------------------------------------------------------------------
+   loadrt neg
+
+   newinst neg <newinstname> [ pincount=N | iprefix=prefix ] [instanceparamX=X | argX=X ]
+-----------------------------------------------------------------------------------------
+
+FUNCTIONS
+
+-----------------------------------------------------------------------
+   neg.N.funct
+          ( OR <newinstname>.funct (requires a floating-point thread) )
+-----------------------------------------------------------------------
+
+PINS
+
+----------------------------------------------
+   neg.N.in  float in
+          ( OR <newinstname>.in  float in  )
+
+
+   neg.N.out  float out
+          ( OR <newinstname>.out  float out  )
+----------------------------------------------
+
+LICENSE
+
+------
+   GPL
+------
+
+Machinekit Documentation 2015-11-01 NEG(9)

--- a/machinekit-documentation/components/not.asciidoc
+++ b/machinekit-documentation/components/not.asciidoc
@@ -1,0 +1,62 @@
+NOT(9) HAL Component NOT(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+-----------------
+   not - Inverter
+-----------------
+
+SYNOPSIS
+
+------
+   not
+------
+
+USAGE SYNOPSIS
+
+-----------------------------------------------------------------------------------------
+   loadrt not
+
+   newinst not <newinstname> [ pincount=N | iprefix=prefix ] [instanceparamX=X | argX=X ]
+-----------------------------------------------------------------------------------------
+
+FUNCTIONS
+
+-------------------------------------
+   not.N.funct
+          ( OR <newinstname>.funct  )
+-------------------------------------
+
+PINS
+
+--------------------------------------------
+   not.N.in  bit in
+          ( OR <newinstname>.in  bit in  )
+
+
+   not.N.out  bit out
+          ( OR <newinstname>.out  bit out  )
+--------------------------------------------
+
+LICENSE
+
+------
+   GPL
+------
+
+Machinekit Documentation 2015-11-01 NOT(9)

--- a/machinekit-documentation/components/offset.asciidoc
+++ b/machinekit-documentation/components/offset.asciidoc
@@ -1,0 +1,92 @@
+OFFSET(9) HAL Component OFFSET(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+--------------------------------------------------------------------------------
+   offset - Adds an offset to an input, and subtracts it from the feedback value
+--------------------------------------------------------------------------------
+
+SYNOPSIS
+
+---------
+   offset
+---------
+
+USAGE SYNOPSIS
+
+--------------------------------------------------------------------------------------------
+   loadrt offset
+
+   newinst offset <newinstname> [ pincount=N | iprefix=prefix ] [instanceparamX=X | argX=X ]
+--------------------------------------------------------------------------------------------
+
+FUNCTIONS
+
+---------------------------------------------------------------------------------------
+   offset.N.update_output.funct
+          ( OR <newinstname>.update_output.funct (requires a floating-point thread) )
+
+   Updated the output value by adding the offset to the input
+
+   offset.N.update_feedback.funct
+          ( OR <newinstname>.update_feedback.funct (requires a floating-point thread) )
+
+   Update the feedback value by subtracting the offset from the feedback
+---------------------------------------------------------------------------------------
+
+PINS
+
+-------------------------------------------------
+   offset.N.offset  float in
+          ( OR <newinstname>.offset  float in  )
+
+
+   The offset value
+
+   offset.N.in  float in
+          ( OR <newinstname>.in  float in  )
+
+
+   The input value
+
+   offset.N.out  float out
+          ( OR <newinstname>.out  float out  )
+
+
+   The output value
+
+   offset.N.fb_in  float in
+          ( OR <newinstname>.fb_in  float in  )
+
+
+   The feedback input value
+
+   offset.N.fb_out  float out
+          ( OR <newinstname>.fb_out  float out  )
+
+
+   The feedback output value
+-------------------------------------------------
+
+LICENSE
+
+------
+   GPL
+------
+
+Machinekit Documentation 2015-11-01 OFFSET(9)

--- a/machinekit-documentation/components/oneshot.asciidoc
+++ b/machinekit-documentation/components/oneshot.asciidoc
@@ -1,0 +1,112 @@
+ONESHOT(9) HAL Component ONESHOT(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+-------------------------------------
+   oneshot - one-shot pulse generator
+-------------------------------------
+
+SYNOPSIS
+
+----------
+   oneshot
+----------
+
+USAGE SYNOPSIS
+
+---------------------------------------------------------------------------------------------
+   loadrt oneshot
+
+   newinst oneshot <newinstname> [ pincount=N | iprefix=prefix ] [instanceparamX=X | argX=X ]
+---------------------------------------------------------------------------------------------
+
+DESCRIPTION
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+   creates  a  variable-length  output  pulse  when  the input changes state. This function needs to run in a thread which supports floating point (typically the servo thread). This means that the pulse
+          length has to be a multiple of that thread period, typically 1mS.  For a similar function that can run in the base thread, and which offers higher resolution, see "edge".
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+FUNCTIONS
+
+-----------------------------------------------------------------------
+   oneshot.N.funct
+          ( OR <newinstname>.funct (requires a floating-point thread) )
+
+   Produce output pulses from input edges
+-----------------------------------------------------------------------
+
+PINS
+
+--------------------------------------------------------------------
+   oneshot.N.in  bit in
+          ( OR <newinstname>.in  bit in  )
+
+
+   Trigger input
+
+   oneshot.N.out  bit out
+          ( OR <newinstname>.out  bit out  )
+
+
+   Active high pulse
+
+   oneshot.N.out_not  bit out
+          ( OR <newinstname>.out_not  bit out  )
+
+
+   Active low pulse
+
+   oneshot.N.width  float in (default: 0)
+          ( OR <newinstname>.width  float in (default: 0) )
+
+
+   Pulse width in seconds
+
+   oneshot.N.time_left  float out
+          ( OR <newinstname>.time_left  float out  )
+
+
+   Time left in current output pulse
+
+   oneshot.N.retriggerable  bit in (default: true)
+          ( OR <newinstname>.retriggerable  bit in (default: true) )
+
+
+   Allow additional edges to extend pulse
+
+   oneshot.N.rising  bit in (default: true)
+          ( OR <newinstname>.rising  bit in (default: true) )
+
+
+   Trigger on rising edge
+
+   oneshot.N.falling  bit in (default: false)
+          ( OR <newinstname>.falling  bit in (default: false) )
+
+
+   Trigger on falling edge
+--------------------------------------------------------------------
+
+LICENSE
+
+------
+   GPL
+------
+
+Machinekit Documentation 2015-11-01 ONESHOT(9)

--- a/machinekit-documentation/components/or2.asciidoc
+++ b/machinekit-documentation/components/or2.asciidoc
@@ -1,0 +1,75 @@
+OR2(9) HAL Component OR2(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+--------------------------
+   or2 - Two-input OR gate
+--------------------------
+
+SYNOPSIS
+
+------
+   or2
+------
+
+USAGE SYNOPSIS
+
+-----------------------------------------------------------------------------------------
+   loadrt or2
+
+   newinst or2 <newinstname> [ pincount=N | iprefix=prefix ] [instanceparamX=X | argX=X ]
+-----------------------------------------------------------------------------------------
+
+FUNCTIONS
+
+-------------------------------------
+   or2.N.funct
+          ( OR <newinstname>.funct  )
+-------------------------------------
+
+PINS
+
+---------------------------------------------------------------------------------
+   or2.N.in0  bit in
+          ( OR <newinstname>.in0  bit in  )
+
+
+   or2.N.in1  bit in
+          ( OR <newinstname>.in1  bit in  )
+
+
+   or2.N.out  bit out
+          ( OR <newinstname>.out  bit out  )
+
+
+   out is computed from the value of in0 and in1 according to the following rule:
+
+          in0=FALSE in1=FALSE
+                 out=FALSE
+
+          Otherwise,
+                 out=TRUE
+---------------------------------------------------------------------------------
+
+LICENSE
+
+------
+   GPL
+------
+
+Machinekit Documentation 2015-11-01 OR2(9)

--- a/machinekit-documentation/components/orient.asciidoc
+++ b/machinekit-documentation/components/orient.asciidoc
@@ -1,0 +1,130 @@
+ORIENT(9) HAL Component ORIENT(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+----------------------------------------------------------------------------------------------------------------------------
+   orient - Provide a PID command input for orientation mode based on current spindle position, target angle and orient mode
+----------------------------------------------------------------------------------------------------------------------------
+
+SYNOPSIS
+
+---------
+   orient
+---------
+
+USAGE SYNOPSIS
+
+--------------------------------------------------------------------------------------------
+   loadrt orient
+
+   newinst orient <newinstname> [ pincount=N | iprefix=prefix ] [instanceparamX=X | argX=X ]
+--------------------------------------------------------------------------------------------
+
+DESCRIPTION
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+          This component is designed to support a spindle orientation PID loop by providing a command value, and fit with the motion spindle-orient support pins to support the M19 code.
+
+          The  spindle  is assumed to have stopped in an arbitrary position. The spindle encoder position is linked to the  position pin.  The  current value of the position pin is sampled on a positive
+          edge on the enable pin, and command is computed and set as follows: floor(number of full spindle revolutions in the position sampled on positive edge) plus angle/360  (the  fractional  revolu‐
+          tion) +1/-1/0 depending on mode.
+
+          The mode pin is interpreted as follows:
+
+          0: the spindle rotates in the direction with the lesser angle, which may be clockwise or counterclockwise.
+
+          1: the spindle rotates always rotates clockwise to the new angle.
+
+          2: the spindle rotates always rotates counterclockwise to the new angle.
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+HAL USAGE On motion.spindle-orient disconnect the spindle control and
+connect to the orient-pid loop:
+
+--------------------------------------------------------------------------------
+   loadrt orient names=orient
+   loadrt pid    names=orient-pid
+   net orient-angle  motion.spindle-orient-angle orient.angle
+   net orient-mode   motion.spindle-orient-mode  orient.mode
+   net orient-enable motion.spindle-orient       orient.enable orient-pid.enable
+   net spindle-pos    ...encoder..position orient.position orient-pid.feedback
+   net orient-command orient.command orient-pid.command
+--------------------------------------------------------------------------------
+
+FUNCTIONS
+
+-----------------------------------------------------------------------
+   orient.N.funct
+          ( OR <newinstname>.funct (requires a floating-point thread) )
+
+   Update command based on enable, position, mode and angle.
+-----------------------------------------------------------------------
+
+PINS
+
+-------------------------------------------------------------------------------------------
+   orient.N.enable  bit in
+          ( OR <newinstname>.enable  bit in  )
+
+
+   enable angular output for orientation mode
+
+   orient.N.mode  s32 in
+          ( OR <newinstname>.mode  s32 in  )
+
+
+   0: rotate - shortest move; 1: always rotate clockwise; 2: always rotate counterclockwise
+
+   orient.N.position  float in
+          ( OR <newinstname>.position  float in  )
+
+
+   spindle position input, unit 1 rev
+
+   orient.N.angle  float in
+          ( OR <newinstname>.angle  float in  )
+
+
+   orient target position in degrees, 0 <= angle < 360
+
+   orient.N.command  float out
+          ( OR <newinstname>.command  float out  )
+
+
+   target spindle position, input to PID command
+
+   orient.N.poserr  float out
+          ( OR <newinstname>.poserr  float out  )
+
+
+   in degrees - aid for PID tuning
+-------------------------------------------------------------------------------------------
+
+AUTHOR
+
+-------------------
+   Michael Haberler
+-------------------
+
+LICENSE
+
+------
+   GPL
+------
+
+Machinekit Documentation 2015-11-01 ORIENT(9)

--- a/machinekit-documentation/components/orn.asciidoc
+++ b/machinekit-documentation/components/orn.asciidoc
@@ -1,0 +1,80 @@
+ORN(9) HAL Component ORN(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+------------------------
+   orn - N input OR gate
+------------------------
+
+SYNOPSIS
+
+------
+   orn
+------
+
+USAGE SYNOPSIS
+
+-----------------------------------------------------------------------------------------
+   loadrt orn
+
+   newinst orn <newinstname> [ pincount=N | iprefix=prefix ] [instanceparamX=X | argX=X ]
+-----------------------------------------------------------------------------------------
+
+DESCRIPTION
+
+--------------------------------------------------------------------------
+    out is computed from the result of logic or applied to all input pins.
+--------------------------------------------------------------------------
+
+FUNCTIONS
+
+-------------------------------------
+   orn.N.funct
+          ( OR <newinstname>.funct  )
+-------------------------------------
+
+PINS
+
+------------------------------------------------------------
+   orn.N.in#.  bit in (M=0..pincount)
+          ( OR <newinstname>.in#.  bit in (M=0..pincount)  )
+
+
+   orn.N.out  bit out
+          ( OR <newinstname>.out  bit out  )
+------------------------------------------------------------
+
+INST_PARAMETERS
+
+----------------------------
+   pincount int (default: 2)
+----------------------------
+
+AUTHOR
+
+---------------------
+   Alexander Roessler
+---------------------
+
+LICENSE
+
+------
+   GPL
+------
+
+Machinekit Documentation 2015-11-01 ORN(9)

--- a/machinekit-documentation/components/out_to_io.asciidoc
+++ b/machinekit-documentation/components/out_to_io.asciidoc
@@ -1,0 +1,92 @@
+OUT_TO_IO(9) HAL Component OUT_TO_IO(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+-------------------------------------------------------------------------------------
+   out_to_io - converts a signal driven by an out pin to a change sensitive io signal
+-------------------------------------------------------------------------------------
+
+SYNOPSIS
+
+------------
+   out_to_io
+------------
+
+USAGE SYNOPSIS
+
+-----------------------------------------------------------------------------------------------
+   loadrt out_to_io
+
+   newinst out_to_io <newinstname> [ pincount=N | iprefix=prefix ] [instanceparamX=X | argX=X ]
+-----------------------------------------------------------------------------------------------
+
+FUNCTIONS
+
+-----------------------------------------------------------------------
+   out_to_io.N.funct
+          ( OR <newinstname>.funct (requires a floating-point thread) )
+-----------------------------------------------------------------------
+
+PINS
+
+----------------------------------------------------------------
+   out_to_io.N.in_u32  u32 in (default: 0)
+          ( OR <newinstname>.in_u32  u32 in (default: 0) )
+
+
+   out_to_io.N.in_s32  s32 in (default: 0)
+          ( OR <newinstname>.in_s32  s32 in (default: 0) )
+
+
+   out_to_io.N.in_float  float in (default: 0.0)
+          ( OR <newinstname>.in_float  float in (default: 0.0) )
+
+
+   out_to_io.N.in_bit  bit in (default: false)
+          ( OR <newinstname>.in_bit  bit in (default: false) )
+
+
+   out_to_io.N.out_u32  u32 io
+          ( OR <newinstname>.out_u32  u32 io  )
+
+
+   out_to_io.N.out_s32  s32 io
+          ( OR <newinstname>.out_s32  s32 io  )
+
+
+   out_to_io.N.out_float  float io
+          ( OR <newinstname>.out_float  float io  )
+
+
+   out_to_io.N.out_bit  bit io
+          ( OR <newinstname>.out_bit  bit io  )
+----------------------------------------------------------------
+
+AUTHOR
+
+---------------------
+   Alexander Roessler
+---------------------
+
+LICENSE
+
+------
+   GPL
+------
+
+Machinekit Documentation 2015-11-01 OUT_TO_IO(9)

--- a/machinekit-documentation/components/pid.asciidoc
+++ b/machinekit-documentation/components/pid.asciidoc
@@ -1,0 +1,330 @@
+PID(9) HAL Component PID(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+----------------------------------------------------------------------------------------------------------------------
+   pid - HAL component that provides Proportional     Integeral/Derivative control loops.  It is a realtime component.
+----------------------------------------------------------------------------------------------------------------------
+
+SYNOPSIS
+
+------
+   pid
+------
+
+USAGE SYNOPSIS
+
+-----------------------------------------------------------------------------------------
+   loadrt pid
+
+   newinst pid <newinstname> [ pincount=N | iprefix=prefix ] [instanceparamX=X | argX=X ]
+-----------------------------------------------------------------------------------------
+
+DESCRIPTION
+
+-------------------------------------------------------------------------------------
+              HAL component that provides Proportional/
+              Integeral/Derivative control loops.  It is a realtime component.
+
+              The number of pid components is set by the module parameter 'num_chan='
+              when the component is insmod'ed.  Alternatively, use the
+              names= specifier and a list of unique names separated by commas.
+              The names= and num_chan= specifiers are mutually exclusive.
+
+              In this documentation, it is assumed that we are discussing position
+              loops.  However this component can be used to implement other loops
+              such as speed loops, torch height control, and others.
+
+              Each loop has a number of pins and parameters, whose names begin
+              with 'pid.x.', where 'x' is the channel number.  Channel numbers
+              start at zero.
+
+              The three most important pins are 'command', 'feedback', and
+              'output'.  For a position loop, 'command' and 'feedback' are
+              in position units.  For a linear axis, this could be inches,
+              mm, metres, or whatever is relavent.  Likewise, for a angular
+              axis, it could be degrees, radians, etc.  The units of the
+              'output' pin represent the change needed to make the feedback
+              match the command.  As such, for a position loop 'Output' is
+              a velocity, in inches/sec, mm/sec, degrees/sec, etc.
+
+              Each loop has several other pins as well.  'error' is equal to
+              'command' minus 'feedback'.  'enable' is a bit that enables
+              the loop.  If 'enable' is false, all integrators are reset,
+              and the output is forced to zero.  If 'enable' is true, the
+              loop operates normally.
+
+              The PID gains, limits, and other 'tunable' features of the
+              loop are implemented as parameters.  These are as follows:
+
+              Pgain Proportional gain
+              Igain Integral gain
+              Dgain Derivative gain
+              bias  Constant offset on output
+              FF0        Zeroth order Feedforward gain
+              FF1        First order Feedforward gain
+              FF2        Second order Feedforward gain
+              deadband   Amount of error that will be ignored
+              maxerror   Limit on error
+              maxerrorI  Limit on error integrator
+              maxerrorD  Limit on error differentiator
+              maxcmdD    Limit on command differentiator
+              maxcmdDD   Limit on command 2nd derivative
+              maxoutput  Limit on output value
+
+              All of the limits (max____) are implemented such that if the
+              parameter value is zero, there is no limit.
+
+              A number of internal values which may be usefull for testing
+              and tuning are also available as parameters.  To avoid cluttering
+              the parameter list, these are only exported if "debug=1" is
+              specified on the insmod command line.
+
+              errorI     Integral of error
+              errorD     Derivative of error
+              commandD   Derivative of the command
+              commandDD  2nd derivative of the command
+
+              The PID loop calculations are as follows (see the code for
+              all the nitty gritty details):
+
+              error = command - feedback
+              if ( abs(error) < deadband ) then error = 0
+              limit error to +/- maxerror
+              errorI += error * period
+              limit errorI to +/- maxerrorI
+              errorD = (error - previouserror) / period
+              limit errorD to +/- maxerrorD
+              commandD = (command - previouscommand) / period
+              limit commandD to +/- maxcmdD
+              commandDD = (commandD - previouscommandD) / period
+              limit commandDD to +/- maxcmdDD
+              output = bias + error * Pgain + errorI * Igain +
+                       errorD * Dgain + command * FF0 + commandD * FF1 +
+                       commandDD * FF2
+              limit output to +/- maxoutput
+
+              This component exports one function called 'pid.x.do-pid-calcs'
+              for each PID loop.  This allows loops to be included in different
+              threads and execute at different rates.
+-------------------------------------------------------------------------------------
+
+FUNCTIONS
+
+------------------------------------------------------------------------------------
+   pid.N.do_pid_calcs.funct
+          ( OR <newinstname>.do_pid_calcs.funct (requires a floating-point thread) )
+------------------------------------------------------------------------------------
+
+PINS
+
+-----------------------------------------------------------------------------
+   pid.N.enable  bit in (default: false)
+          ( OR <newinstname>.enable  bit in (default: false) )
+
+
+   Enable/disabled the PID loop
+
+   pid.N.command  float in (default: 0.0)
+          ( OR <newinstname>.command  float in (default: 0.0) )
+
+
+   Commanded value
+
+   pid.N.command_deriv  float in (default: 0.0)
+          ( OR <newinstname>.command_deriv  float in (default: 0.0) )
+
+
+   Derivative command input
+
+   pid.N.feedback  float in (default: 0.0)
+          ( OR <newinstname>.feedback  float in (default: 0.0) )
+
+
+   Feedback input
+
+   pid.N.feedback_deriv  float in (default: 0.0)
+          ( OR <newinstname>.feedback_deriv  float in (default: 0.0) )
+
+
+   Derivative feedback input
+
+   pid.N.error  float out
+          ( OR <newinstname>.error  float out  )
+
+
+   Current error
+
+   pid.N.output  float out
+          ( OR <newinstname>.output  float out  )
+
+
+   Ouput value
+
+   pid.N.saturated  bit out
+          ( OR <newinstname>.saturated  bit out  )
+
+
+   If the PID loop is saturated
+
+   pid.N.saturated_s  float out
+          ( OR <newinstname>.saturated_s  float out  )
+
+
+   Saturated time
+
+   pid.N.saturated_count  s32 out
+          ( OR <newinstname>.saturated_count  s32 out  )
+
+
+   How often the PID loop was saturated
+
+   pid.N.Pgain  float in (default: 1.0)
+          ( OR <newinstname>.Pgain  float in (default: 1.0) )
+
+
+   Proportional gain
+
+   pid.N.Igain  float in (default: 0.0)
+          ( OR <newinstname>.Igain  float in (default: 0.0) )
+
+
+   Integral gain
+
+   pid.N.Dgain  float in (default: 0.0)
+          ( OR <newinstname>.Dgain  float in (default: 0.0) )
+
+
+   Derivative gain
+
+   pid.N.bias  float in (default: 0.0)
+          ( OR <newinstname>.bias  float in (default: 0.0) )
+
+
+   Constant offset on output
+
+   pid.N.FF0  float in (default: 0.0)
+          ( OR <newinstname>.FF0  float in (default: 0.0) )
+
+
+   Zeroth order Feedforward gain
+
+   pid.N.FF1  float in (default: 0.0)
+          ( OR <newinstname>.FF1  float in (default: 0.0) )
+
+
+   First order Feedforward gain
+
+   pid.N.FF2  float in (default: 0.0)
+          ( OR <newinstname>.FF2  float in (default: 0.0) )
+
+
+   Second order Feedforward gain
+
+   pid.N.deadband  float in (default: 0.0)
+          ( OR <newinstname>.deadband  float in (default: 0.0) )
+
+
+   Amount of error that will be ignored
+
+   pid.N.maxerror  float in (default: 0.0)
+          ( OR <newinstname>.maxerror  float in (default: 0.0) )
+
+
+   Limit on error
+
+   pid.N.maxerrorI  float in (default: 0.0)
+          ( OR <newinstname>.maxerrorI  float in (default: 0.0) )
+
+
+   Limit on error integrator
+
+   pid.N.maxerrorD  float in (default: 0.0)
+          ( OR <newinstname>.maxerrorD  float in (default: 0.0) )
+
+
+   Limit on error differentiator
+
+   pid.N.maxcmdD  float in (default: 0.0)
+          ( OR <newinstname>.maxcmdD  float in (default: 0.0) )
+
+
+   Limit on command differentiator
+
+   pid.N.maxcmdDD  float in (default: 0.0)
+          ( OR <newinstname>.maxcmdDD  float in (default: 0.0) )
+
+
+   Limit on command 2nd derivative
+
+   pid.N.maxoutput  float in (default: 0.0)
+          ( OR <newinstname>.maxoutput  float in (default: 0.0) )
+
+
+   Limit on output value
+
+   pid.N.index_enable  bit in (default: false)
+          ( OR <newinstname>.index_enable  bit in (default: false) )
+
+
+   Index enable
+
+   pid.N.error_previous_target  bit in (default: false)
+          ( OR <newinstname>.error_previous_target  bit in (default: false) )
+
+
+   Error previous target
+
+   pid.N.errorI  float out
+          ( OR <newinstname>.errorI  float out  )
+
+
+   Integral of error
+
+   pid.N.errorD  float out
+          ( OR <newinstname>.errorD  float out  )
+
+
+   Derivative of error
+
+   pid.N.commandD  float out
+          ( OR <newinstname>.commandD  float out  )
+
+
+   Derivative of the command
+
+   pid.N.commandDD  float out
+          ( OR <newinstname>.commandDD  float out  )
+
+
+   2nd derivative of the command
+-----------------------------------------------------------------------------
+
+AUTHOR
+
+----------------
+   John Kasunich
+----------------
+
+LICENSE
+
+---------
+   GPL v2
+---------
+
+Machinekit Documentation 2015-11-01 PID(9)

--- a/machinekit-documentation/components/reset.asciidoc
+++ b/machinekit-documentation/components/reset.asciidoc
@@ -1,0 +1,135 @@
+RESET(9) HAL Component RESET(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+-----------------------------
+   reset - Resets a IO signal
+-----------------------------
+
+SYNOPSIS
+
+--------
+   reset
+--------
+
+USAGE SYNOPSIS
+
+-------------------------------------------------------------------------------------------
+   loadrt reset
+
+   newinst reset <newinstname> [ pincount=N | iprefix=prefix ] [instanceparamX=X | argX=X ]
+-------------------------------------------------------------------------------------------
+
+DESCRIPTION
+
+----------------------------------------
+          Component to reset IO signals.
+----------------------------------------
+
+FUNCTIONS
+
+-----------------------------------------------------------------------
+   reset.N.funct
+          ( OR <newinstname>.funct (requires a floating-point thread) )
+
+   Update the output value
+-----------------------------------------------------------------------
+
+PINS
+
+--------------------------------------------------------------------
+   reset.N.trigger  bit in
+          ( OR <newinstname>.trigger  bit in  )
+
+
+   Trigger input
+
+   reset.N.out_u32  u32 io (default: 0)
+          ( OR <newinstname>.out_u32  u32 io (default: 0) )
+
+
+   Unsigned 32 bit integer output value
+
+   reset.N.reset_u32  u32 in (default: 0)
+          ( OR <newinstname>.reset_u32  u32 in (default: 0) )
+
+
+   Unsigned 32 bit integer reset value
+
+   reset.N.out_s32  s32 io (default: 0)
+          ( OR <newinstname>.out_s32  s32 io (default: 0) )
+
+
+   Signed 32 bit integer output value
+
+   reset.N.reset_s32  s32 in (default: 0)
+          ( OR <newinstname>.reset_s32  s32 in (default: 0) )
+
+
+   Signed 32 bit integer reset value
+
+   reset.N.out_float  float io (default: 0.0)
+          ( OR <newinstname>.out_float  float io (default: 0.0) )
+
+
+   Float output value
+
+   reset.N.reset_float  float in (default: 0.0)
+          ( OR <newinstname>.reset_float  float in (default: 0.0) )
+
+
+   Float reset value
+
+   reset.N.out_bit  bit io (default: false)
+          ( OR <newinstname>.out_bit  bit io (default: false) )
+
+
+   Bit integer output value
+
+   reset.N.reset_bit  bit in (default: false)
+          ( OR <newinstname>.reset_bit  bit in (default: false) )
+
+
+   Bit reset value
+
+   reset.N.retriggerable  bit in (default: true)
+          ( OR <newinstname>.retriggerable  bit in (default: true) )
+
+
+   Allow additional edges to reset
+
+   reset.N.rising  bit in (default: true)
+          ( OR <newinstname>.rising  bit in (default: true) )
+
+
+   Trigger on rising edge
+
+   reset.N.falling  bit in (default: false)
+          ( OR <newinstname>.falling  bit in (default: false) )
+
+
+   Trigger on falling edge
+--------------------------------------------------------------------
+
+LICENSE
+
+------
+   GPL
+------
+
+Machinekit Documentation 2015-11-01 RESET(9)

--- a/machinekit-documentation/components/safety_latch.asciidoc
+++ b/machinekit-documentation/components/safety_latch.asciidoc
@@ -1,0 +1,146 @@
+SAFETY_LATCH(9) HAL Component SAFETY_LATCH(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+-----------------------------------------
+   safety_latch - latch for error signals
+-----------------------------------------
+
+SYNOPSIS
+
+---------------
+   safety_latch
+---------------
+
+USAGE SYNOPSIS
+
+--------------------------------------------------------------------------------------------------
+   loadrt safety_latch
+
+   newinst safety_latch <newinstname> [ pincount=N | iprefix=prefix ] [instanceparamX=X | argX=X ]
+--------------------------------------------------------------------------------------------------
+
+DESCRIPTION
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+          HAL component that implements a safety latch for error singnals with customizable harm, healing and latching features.
+
+          When the component is not enabled the error input value is forwarded to output without further modififactions.
+
+          If  error-in  is  true  the  error count is increased by harm.  If error-in is false the error count is decreased by heal.  When the error count exceeds the threscold value error-out is set to
+          true. If latching is false the error-out pin will only return to false when reset is set to true.
+
+          The inputs pin min and max clamp the error count value to a specified range.
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+FUNCTIONS
+
+-------------------------------------
+   safety_latch.N.funct
+          ( OR <newinstname>.funct  )
+-------------------------------------
+
+PINS
+
+------------------------------------------------------------------
+   safety_latch.N.error_in  bit in (default: false)
+          ( OR <newinstname>.error_in  bit in (default: false) )
+
+
+   Error Input
+
+   safety_latch.N.heal  s32 in (default: 1)
+          ( OR <newinstname>.heal  s32 in (default: 1) )
+
+
+   Heal when ok per tick
+
+   safety_latch.N.harm  s32 in (default: 1)
+          ( OR <newinstname>.harm  s32 in (default: 1) )
+
+
+   Harm when error per tick
+
+   safety_latch.N.latching  bit in (default: true)
+          ( OR <newinstname>.latching  bit in (default: true) )
+
+
+   If a reset is necessary to heal an error
+
+   safety_latch.N.reset  bit in (default: false)
+          ( OR <newinstname>.reset  bit in (default: false) )
+
+
+   Reset input
+
+   safety_latch.N.threshold  s32 in (default: 100)
+          ( OR <newinstname>.threshold  s32 in (default: 100) )
+
+
+   Error output threshold
+
+   safety_latch.N.min  s32 in (default: 0)
+          ( OR <newinstname>.min  s32 in (default: 0) )
+
+
+   Minimum count
+
+   safety_latch.N.max  s32 in (default: 1000)
+          ( OR <newinstname>.max  s32 in (default: 1000) )
+
+
+   Maximum count
+
+   safety_latch.N.enable  bit in (default: true)
+          ( OR <newinstname>.enable  bit in (default: true) )
+
+
+   If not enabled the error count is passed to the output
+
+   safety_latch.N.count  s32 out (default: 0)
+          ( OR <newinstname>.count  s32 out (default: 0) )
+
+
+   Current count
+
+   safety_latch.N.error_out  bit out (default: false)
+          ( OR <newinstname>.error_out  bit out (default: false) )
+
+
+   Error output
+
+   safety_latch.N.ok_out  bit out (default: true)
+          ( OR <newinstname>.ok_out  bit out (default: true) )
+
+
+   Ok output
+------------------------------------------------------------------
+
+AUTHOR
+
+---------------------
+   Alexander Roessler
+---------------------
+
+LICENSE
+
+------
+   GPL
+------
+
+Machinekit Documentation 2015-11-01 SAFETY_LATCH(9)

--- a/machinekit-documentation/components/sample_hold.asciidoc
+++ b/machinekit-documentation/components/sample_hold.asciidoc
@@ -1,0 +1,66 @@
+SAMPLE_HOLD(9) HAL Component SAMPLE_HOLD(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+--------------------------------
+   sample_hold - Sample and Hold
+--------------------------------
+
+SYNOPSIS
+
+--------------
+   sample_hold
+--------------
+
+USAGE SYNOPSIS
+
+-------------------------------------------------------------------------------------------------
+   loadrt sample_hold
+
+   newinst sample_hold <newinstname> [ pincount=N | iprefix=prefix ] [instanceparamX=X | argX=X ]
+-------------------------------------------------------------------------------------------------
+
+FUNCTIONS
+
+-------------------------------------
+   sample_hold.N.funct
+          ( OR <newinstname>.funct  )
+-------------------------------------
+
+PINS
+
+--------------------------------------------
+   sample_hold.N.in  s32 in
+          ( OR <newinstname>.in  s32 in  )
+
+
+   sample_hold.N.hold  bit in
+          ( OR <newinstname>.hold  bit in  )
+
+
+   sample_hold.N.out  s32 out
+          ( OR <newinstname>.out  s32 out  )
+--------------------------------------------
+
+LICENSE
+
+------
+   GPL
+------
+
+Machinekit Documentation 2015-11-01 SAMPLE_HOLD(9)

--- a/machinekit-documentation/components/scale.asciidoc
+++ b/machinekit-documentation/components/scale.asciidoc
@@ -1,0 +1,73 @@
+SCALE(9) HAL Component SCALE(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+--------------------------------------------------------------------------------
+   scale - Machinekit HAL component that applies a scale and offset to its input
+--------------------------------------------------------------------------------
+
+SYNOPSIS
+
+--------
+   scale
+--------
+
+USAGE SYNOPSIS
+
+-------------------------------------------------------------------------------------------
+   loadrt scale
+
+   newinst scale <newinstname> [ pincount=N | iprefix=prefix ] [instanceparamX=X | argX=X ]
+-------------------------------------------------------------------------------------------
+
+FUNCTIONS
+
+-----------------------------------------------------------------------
+   scale.N.funct
+          ( OR <newinstname>.funct (requires a floating-point thread) )
+-----------------------------------------------------------------------
+
+PINS
+
+------------------------------------------------
+   scale.N.in  float in
+          ( OR <newinstname>.in  float in  )
+
+
+   scale.N.gain  float in
+          ( OR <newinstname>.gain  float in  )
+
+
+   scale.N.offset  float in
+          ( OR <newinstname>.offset  float in  )
+
+
+   scale.N.out  float out
+          ( OR <newinstname>.out  float out  )
+
+
+   out = in * gain + offset
+------------------------------------------------
+
+LICENSE
+
+------
+   GPL
+------
+
+Machinekit Documentation 2015-11-01 SCALE(9)

--- a/machinekit-documentation/components/select8.asciidoc
+++ b/machinekit-documentation/components/select8.asciidoc
@@ -1,0 +1,73 @@
+SELECT8(9) HAL Component SELECT8(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+----------------------------------------
+   select8 - 8-bit binary match detector
+----------------------------------------
+
+SYNOPSIS
+
+----------
+   select8
+----------
+
+USAGE SYNOPSIS
+
+---------------------------------------------------------------------------------------------
+   loadrt select8
+
+   newinst select8 <newinstname> [ pincount=N | iprefix=prefix ] [instanceparamX=X | argX=X ]
+---------------------------------------------------------------------------------------------
+
+FUNCTIONS
+
+-------------------------------------
+   select8.N.funct
+          ( OR <newinstname>.funct  )
+-------------------------------------
+
+PINS
+
+--------------------------------------------------------------------------------------------------------------------------
+   select8.N.enable  bit io (default: true)
+          ( OR <newinstname>.enable  bit io (default: true) )
+
+
+   Set enable to false to cause all outputs to be set false
+
+   select8.N.sel  s32 in
+          ( OR <newinstname>.sel  s32 in  )
+
+
+   The number of the output to set true.  All other outputs well be set false
+
+   select8.N.out#  bit out (M=0..8)
+          ( OR <newinstname>.out#  bit out (M=0..8)  )
+
+
+   Output bits.  If enable is set and the sel input is between 0 and 7, then the corresponding output bit will be set true
+--------------------------------------------------------------------------------------------------------------------------
+
+LICENSE
+
+------
+   GPL
+------
+
+Machinekit Documentation 2015-11-01 SELECT8(9)

--- a/machinekit-documentation/components/selectn.asciidoc
+++ b/machinekit-documentation/components/selectn.asciidoc
@@ -1,0 +1,85 @@
+SELECTN(9) HAL Component SELECTN(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+----------------------------
+   selectn - select one of n
+----------------------------
+
+SYNOPSIS
+
+----------
+   selectn
+----------
+
+USAGE SYNOPSIS
+
+---------------------------------------------------------------------------------------------
+   loadrt selectn
+
+   newinst selectn <newinstname> [ pincount=N | iprefix=prefix ] [instanceparamX=X | argX=X ]
+---------------------------------------------------------------------------------------------
+
+FUNCTIONS
+
+-------------------------------------
+   selectn.N.funct
+          ( OR <newinstname>.funct  )
+-------------------------------------
+
+PINS
+
+--------------------------------------------------------------------------------------------------------------------------
+   selectn.N.enable  bit io (default: true)
+          ( OR <newinstname>.enable  bit io (default: true) )
+
+
+   Set enable to false to cause all outputs to be set false
+
+   selectn.N.sel  s32 in
+          ( OR <newinstname>.sel  s32 in  )
+
+
+   The number of the output to set true.  All other outputs well be set false
+
+   selectn.N.out#  bit out (M=0..pincount)
+          ( OR <newinstname>.out#  bit out (M=0..pincount)  )
+
+
+   Output bits.  If enable is set and the sel input is between 0 and 7, then the corresponding output bit will be set true
+--------------------------------------------------------------------------------------------------------------------------
+
+INST_PARAMETERS
+
+----------------------------
+   pincount int (default: 2)
+----------------------------
+
+AUTHOR
+
+---------------------
+   Alexander Roessler
+---------------------
+
+LICENSE
+
+------
+   GPL
+------
+
+Machinekit Documentation 2015-11-01 SELECTN(9)

--- a/machinekit-documentation/components/sphereprobe.asciidoc
+++ b/machinekit-documentation/components/sphereprobe.asciidoc
@@ -1,0 +1,100 @@
+SPHEREPROBE(9) HAL Component SPHEREPROBE(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+-------------------------------------------
+   sphereprobe - Probe a pretend hemisphere
+-------------------------------------------
+
+SYNOPSIS
+
+--------------
+   sphereprobe
+--------------
+
+USAGE SYNOPSIS
+
+-------------------------------------------------------------------------------------------------
+   loadrt sphereprobe
+
+   newinst sphereprobe <newinstname> [ pincount=N | iprefix=prefix ] [instanceparamX=X | argX=X ]
+-------------------------------------------------------------------------------------------------
+
+FUNCTIONS
+
+-------------------------------------
+   sphereprobe.N.funct
+          ( OR <newinstname>.funct  )
+
+   update probe-out based on inputs
+-------------------------------------
+
+PINS
+
+--------------------------------------------------
+   sphereprobe.N.px  s32 in
+          ( OR <newinstname>.px  s32 in  )
+
+
+   sphereprobe.N.py  s32 in
+          ( OR <newinstname>.py  s32 in  )
+
+
+   sphereprobe.N.pz  s32 in
+          ( OR <newinstname>.pz  s32 in  )
+
+
+   rawcounts position from software encoder
+
+   sphereprobe.N.cx  s32 in
+          ( OR <newinstname>.cx  s32 in  )
+
+
+   sphereprobe.N.cy  s32 in
+          ( OR <newinstname>.cy  s32 in  )
+
+
+   sphereprobe.N.cz  s32 in
+          ( OR <newinstname>.cz  s32 in  )
+
+
+   Center of sphere in counts
+
+   sphereprobe.N.r  s32 in
+          ( OR <newinstname>.r  s32 in  )
+
+
+   Radius of hemisphere in counts
+
+   sphereprobe.N.probe-out  bit out
+          ( OR <newinstname>.probe-out  bit out  )
+--------------------------------------------------
+
+AUTHOR
+
+-------------
+   Jeff Epler
+-------------
+
+LICENSE
+
+------
+   GPL
+------
+
+Machinekit Documentation 2015-11-01 SPHEREPROBE(9)

--- a/machinekit-documentation/components/stats.asciidoc
+++ b/machinekit-documentation/components/stats.asciidoc
@@ -1,0 +1,74 @@
+STATS(9) HAL Component STATS(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+-----------------------------------------------
+   stats - compute mean and variance of a value
+-----------------------------------------------
+
+SYNOPSIS
+
+--------
+   stats
+--------
+
+USAGE SYNOPSIS
+
+-------------------------------------------------------------------------------------------
+   loadrt stats
+
+   newinst stats <newinstname> [ pincount=N | iprefix=prefix ] [instanceparamX=X | argX=X ]
+-------------------------------------------------------------------------------------------
+
+FUNCTIONS
+
+-----------------------------------------------------------------------
+   stats.N.funct
+          ( OR <newinstname>.funct (requires a floating-point thread) )
+-----------------------------------------------------------------------
+
+PINS
+
+---------------------------------------------------
+   stats.N.in  float in
+          ( OR <newinstname>.in  float in  )
+
+
+   stats.N.enable  bit in
+          ( OR <newinstname>.enable  bit in  )
+
+
+   stats.N.mean  float out
+          ( OR <newinstname>.mean  float out  )
+
+
+   stats.N.variance  float out
+          ( OR <newinstname>.variance  float out  )
+
+
+   stats.N.n  u32 out
+          ( OR <newinstname>.n  u32 out  )
+---------------------------------------------------
+
+LICENSE
+
+------
+   GPL
+------
+
+Machinekit Documentation 2015-11-01 STATS(9)

--- a/machinekit-documentation/components/sum2.asciidoc
+++ b/machinekit-documentation/components/sum2.asciidoc
@@ -1,0 +1,81 @@
+SUM2(9) HAL Component SUM2(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+------------------------------------------------------------
+   sum2 - Sum of two inputs (each with a gain) and an offset
+------------------------------------------------------------
+
+SYNOPSIS
+
+-------
+   sum2
+-------
+
+USAGE SYNOPSIS
+
+------------------------------------------------------------------------------------------
+   loadrt sum2
+
+   newinst sum2 <newinstname> [ pincount=N | iprefix=prefix ] [instanceparamX=X | argX=X ]
+------------------------------------------------------------------------------------------
+
+FUNCTIONS
+
+-----------------------------------------------------------------------
+   sum2.N.funct
+          ( OR <newinstname>.funct (requires a floating-point thread) )
+-----------------------------------------------------------------------
+
+PINS
+
+-------------------------------------------------------------
+   sum2.N.in0  float in
+          ( OR <newinstname>.in0  float in  )
+
+
+   sum2.N.in1  float in
+          ( OR <newinstname>.in1  float in  )
+
+
+   sum2.N.gain0  float io (default: 1.0)
+          ( OR <newinstname>.gain0  float io (default: 1.0) )
+
+
+   sum2.N.gain1  float io (default: 1.0)
+          ( OR <newinstname>.gain1  float io (default: 1.0) )
+
+
+   sum2.N.offset  float io
+          ( OR <newinstname>.offset  float io  )
+
+
+   sum2.N.out  float out
+          ( OR <newinstname>.out  float out  )
+
+
+   out = in0 * gain0 + in1 * gain1 + offset
+-------------------------------------------------------------
+
+LICENSE
+
+------
+   GPL
+------
+
+Machinekit Documentation 2015-11-01 SUM2(9)

--- a/machinekit-documentation/components/thc.asciidoc
+++ b/machinekit-documentation/components/thc.asciidoc
@@ -1,0 +1,202 @@
+THC(9) HAL Component THC(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+-----------------------------
+   thc - Torch Height Control
+-----------------------------
+
+SYNOPSIS
+
+------
+   thc
+------
+
+USAGE SYNOPSIS
+
+-----------------------------------------------------------------------------------------
+   loadrt thc
+
+   newinst thc <newinstname> [ pincount=N | iprefix=prefix ] [instanceparamX=X | argX=X ]
+-----------------------------------------------------------------------------------------
+
+DESCRIPTION
+
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+          Torch Height Control Mesa THC > Encoder > Machinekit THC component
+
+          The Mesa THC sends a frequency based on the voltage detected to the encoder.  The velocity from the encoder is converted to volts with the velocity scale parameter inside the THC component.
+
+          The THCAD card sends a frequency at 0 volts so the scale offset parameter is used to zero the calculated voltage.
+
+          Component Functions If enabled and torch is on and X + Y velocity is within tolerance of set speed allow the THC to offset the Z axis as needed to maintain voltage.
+
+          If enabled and torch is off and the Z axis is moving up remove any correction at a rate not to exceed the rate of movement of the Z axis.
+
+          If enabled and torch is off and there is no correction pass the Z position and feed back untouched.
+
+          If not enabled pass the Z position and feed back untouched.
+
+          Physical Connections
+          Plasma Torch Arc Voltage Signal => 6 x 487k 1% resistors => THC Arc Voltage In
+          THC Frequency Signal => Encoder #0, pin A (Input)
+          Plasma Torch Arc OK Signal => input pin
+          output pin => Plasma Torch Start Arc Contacts
+
+          HAL Plasma Connections
+          encoder.nn.velocity => thc.encoder-vel (tip voltage)
+          motion.spindle-on => output pin (start the arc)
+          thc.arc-ok <= motion.digital-in-00 <= input pin (arc ok signal)
+
+          HAL Motion Connections
+          thc.requested-vel <= motion.requested-vel
+          thc.current-vel <= motion.current-vel
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+FUNCTIONS
+
+-----------------------------------------------------------------------
+   thc.N.funct
+          ( OR <newinstname>.funct (requires a floating-point thread) )
+-----------------------------------------------------------------------
+
+PINS
+
+---------------------------------------------------------------------
+   thc.N.encoder_vel  float in
+          ( OR <newinstname>.encoder_vel  float in  )
+
+
+   Connect to hm2_5i20.0.encoder.00.velocity
+
+   thc.N.current_vel  float in
+          ( OR <newinstname>.current_vel  float in  )
+
+
+   Connect to motion.current-vel
+
+   thc.N.requested_vel  float in
+          ( OR <newinstname>.requested_vel  float in  )
+
+
+   Connect to motion.requested-vel
+
+   thc.N.volts_requested  float in
+          ( OR <newinstname>.volts_requested  float in  )
+
+
+   Tip Volts current_vel >= min_velocity requested
+
+   thc.N.vel_tol  float in
+          ( OR <newinstname>.vel_tol  float in  )
+
+
+   Velocity Tolerance (Corner Lock)
+
+   thc.N.torch_on  bit in
+          ( OR <newinstname>.torch_on  bit in  )
+
+
+   Connect to motion.spindle-on
+
+   thc.N.arc_ok  bit in
+          ( OR <newinstname>.arc_ok  bit in  )
+
+
+   Arc OK from Plasma Torch
+
+   thc.N.enable  bit in
+          ( OR <newinstname>.enable  bit in  )
+
+
+   Enable the THC, if not enabled Z position is passed through
+
+   thc.N.z_pos_in  float in
+          ( OR <newinstname>.z_pos_in  float in  )
+
+
+   Z Motor Position Command in from axis.n.motor-pos-cmd
+
+   thc.N.z_pos_out  float out
+          ( OR <newinstname>.z_pos_out  float out  )
+
+
+   Z Motor Position Command Out
+
+   thc.N.z_fb_out  float out
+          ( OR <newinstname>.z_fb_out  float out  )
+
+
+   Z Position Feedback to Axis
+
+   thc.N.volts  float out
+          ( OR <newinstname>.volts  float out  )
+
+
+   The Calculated Volts
+
+   thc.N.vel_status  bit out
+          ( OR <newinstname>.vel_status  bit out  )
+
+
+   When the THC thinks we are at requested speed
+
+   thc.N.vel_scale  float io
+          ( OR <newinstname>.vel_scale  float io  )
+
+
+   The scale to convert the Velocity signal to Volts
+
+   thc.N.scale_offset  float io
+          ( OR <newinstname>.scale_offset  float io  )
+
+
+   The offset of the velocity input at 0 volts
+
+   thc.N.velocity_tol  float io
+          ( OR <newinstname>.velocity_tol  float io  )
+
+
+   The deviation percent from planned velocity
+
+   thc.N.voltage_tol  float io
+          ( OR <newinstname>.voltage_tol  float io  )
+
+
+   The deviation of Tip Voltage before correction takes place
+
+   thc.N.correction_vel  float io
+          ( OR <newinstname>.correction_vel  float io  )
+
+
+   The amount of change in user units per period to move Z to correct
+---------------------------------------------------------------------
+
+AUTHOR
+
+----------------
+   John Thornton
+----------------
+
+LICENSE
+
+-------------------
+   GPLv2 or greater
+-------------------
+
+Machinekit Documentation 2015-11-01 THC(9)

--- a/machinekit-documentation/components/thcud.asciidoc
+++ b/machinekit-documentation/components/thcud.asciidoc
@@ -1,0 +1,191 @@
+THCUD(9) HAL Component THCUD(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+---------------------------------------------
+   thcud - Torch Height Control Up/Down Input
+---------------------------------------------
+
+SYNOPSIS
+
+--------
+   thcud
+--------
+
+USAGE SYNOPSIS
+
+-------------------------------------------------------------------------------------------
+   loadrt thcud
+
+   newinst thcud <newinstname> [ pincount=N | iprefix=prefix ] [instanceparamX=X | argX=X ]
+-------------------------------------------------------------------------------------------
+
+DESCRIPTION
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+          Torch Height Control This THC takes either an up or a down input from a THC
+
+          If enabled and torch is on and X + Y velocity is within tolerance of set speed allow the THC to offset the Z axis as needed to maintain voltage.
+
+          If enabled and torch is off and the Z axis is moving up remove any correction at a rate not to exceed the rate of movement of the Z axis.
+
+          If enabled and torch is off and there is no correction pass the Z position and feed back untouched.
+
+          If not enabled pass the Z position and feed back untouched.
+
+          Physical  Connections  typical  paraport.0.pin-12-in  <=  THC  controller  Plasma  Up paraport.0.pin-13-in <= THC controller Plasma Down parport.0.pin-15-in  <= Plasma Torch Arc Ok Signal par‐
+          port.0.pin-16-out => Plasma Torch Start Arc Contacts
+
+          HAL Plasma Connections thc.torch-up <= paraport.0.pin-12-in thc.torch-down <= paraport.0.pin-13-in motion.spindle-on => parport.0.pin-16-out (start the arc) thc.arc-ok <=  motion.digital-in-00
+          <= parport.0.pin-15-in (arc ok signal)
+
+          HAL Motion Connections thc.requested-vel <= motion.requested-vel thc.current-vel <= motion.current-vel
+
+          Pyvcp Connections In the xml file you need something like:
+
+          <checkbutton>
+            <text>"THC Enable"</text>
+            <halpin>"thc-enable"</halpin> </checkbutton> <spinbox>
+            <width>"5"</width>
+            <halpin>"vel-tol"</halpin>
+            <min_>.01</min_>
+            <max_>1</max_>
+            <resolution>0.01</resolution>
+            <initval>0.2</initval>
+            <format>"1.2f"</format>
+            <font>("Arial",10)</font> </spinbox>
+
+          Connect the Pyvcp pins in the postgui.hal file like this:
+
+          net thc-enable thcud.enable <= pyvcp.thc-enable
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+FUNCTIONS
+
+-----------------------------------------------------------------------
+   thcud.N.funct
+          ( OR <newinstname>.funct (requires a floating-point thread) )
+-----------------------------------------------------------------------
+
+PINS
+
+--------------------------------------------------------------
+   thcud.N.torch_up  bit in
+          ( OR <newinstname>.torch_up  bit in  )
+
+
+   Connect to an input pin
+
+   thcud.N.torch_down  bit in
+          ( OR <newinstname>.torch_down  bit in  )
+
+
+   Connect to input pin
+
+   thcud.N.current_vel  float in
+          ( OR <newinstname>.current_vel  float in  )
+
+
+   Connect to motion.current-vel
+
+   thcud.N.requested_vel  float in
+          ( OR <newinstname>.requested_vel  float in  )
+
+
+   Connect to motion.requested-vel
+
+   thcud.N.torch_on  bit in
+          ( OR <newinstname>.torch_on  bit in  )
+
+
+   Connect to motion.spindle-on
+
+   thcud.N.arc_ok  bit in
+          ( OR <newinstname>.arc_ok  bit in  )
+
+
+   Arc Ok from Plasma Torch
+
+   thcud.N.enable  bit in
+          ( OR <newinstname>.enable  bit in  )
+
+
+   Enable the THC, if not enabled Z position is passed through
+
+   thcud.N.z_pos_in  float in
+          ( OR <newinstname>.z_pos_in  float in  )
+
+
+   Z Motor Position Command in from axis.n.motor-pos-cmd
+
+   thcud.N.z_pos_out  float out
+          ( OR <newinstname>.z_pos_out  float out  )
+
+
+   Z Motor Position Command Out
+
+   thcud.N.z_fb_out  float out
+          ( OR <newinstname>.z_fb_out  float out  )
+
+
+   Z Position Feedback to Axis
+
+   thcud.N.cur_offset  float out
+          ( OR <newinstname>.cur_offset  float out  )
+
+
+   The Current Offset
+
+   thcud.N.vel_status  bit out
+          ( OR <newinstname>.vel_status  bit out  )
+
+
+   When the THC thinks we are at requested speed
+
+   thcud.N.removing_offset  bit out
+          ( OR <newinstname>.removing_offset  bit out  )
+
+
+   Pin for testing
+
+   thcud.N.velocity_tol  float io
+          ( OR <newinstname>.velocity_tol  float io  )
+
+
+   The deviation percent from planned velocity
+
+   thcud.N.correction_vel  float io
+          ( OR <newinstname>.correction_vel  float io  )
+
+
+   The Velocity to move Z to correct
+--------------------------------------------------------------
+
+AUTHOR
+
+----------------
+   John Thornton
+----------------
+
+LICENSE
+
+-------------------
+   GPLv2 or greater
+-------------------
+
+Machinekit Documentation 2015-11-01 THCUD(9)

--- a/machinekit-documentation/components/threadtest.asciidoc
+++ b/machinekit-documentation/components/threadtest.asciidoc
@@ -1,0 +1,64 @@
+THREADTEST(9) HAL Component THREADTEST(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+--------------------------------------------------------------------
+   threadtest - Machinekit HAL component for testing thread behavior
+--------------------------------------------------------------------
+
+SYNOPSIS
+
+-------------
+   threadtest
+-------------
+
+USAGE SYNOPSIS
+
+------------------------------------------------------------------------------------------------
+   loadrt threadtest
+
+   newinst threadtest <newinstname> [ pincount=N | iprefix=prefix ] [instanceparamX=X | argX=X ]
+------------------------------------------------------------------------------------------------
+
+FUNCTIONS
+
+-----------------------------------------------
+   threadtest.N.increment.funct
+          ( OR <newinstname>.increment.funct  )
+
+
+
+
+   threadtest.N.reset.funct
+          ( OR <newinstname>.reset.funct  )
+-----------------------------------------------
+
+PINS
+
+----------------------------------------------
+   threadtest.N.count  u32 out
+          ( OR <newinstname>.count  u32 out  )
+----------------------------------------------
+
+LICENSE
+
+------
+   GPL
+------
+
+Machinekit Documentation 2015-11-01 THREADTEST(9)

--- a/machinekit-documentation/components/time.asciidoc
+++ b/machinekit-documentation/components/time.asciidoc
@@ -1,0 +1,141 @@
+TIME(9) HAL Component TIME(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+--------------------------------------------
+   time - Time on in Hours, Minutes, Seconds
+--------------------------------------------
+
+SYNOPSIS
+
+-------
+   time
+-------
+
+USAGE SYNOPSIS
+
+------------------------------------------------------------------------------------------
+   loadrt time
+
+   newinst time <newinstname> [ pincount=N | iprefix=prefix ] [instanceparamX=X | argX=X ]
+------------------------------------------------------------------------------------------
+
+DESCRIPTION
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+          Time
+
+          When the time.N.start bit goes true the cycle timer resets and starts to time until time.N.start goes false. If you connect time.N.start to halui.is-running as a cycle timer it will reset dur‐
+          ing a pause. See the example connections below to keep the timer timing during a pause.
+
+          Time returns the hours, minutes, and seconds that time.N.start is true.
+
+          Sample pyVCP code to display the hours:minutes:seconds.
+
+          <pyvcp>
+            <hbox>
+            <label>
+              <text>"Cycle Time"</text>
+              <font>("Helvetica",14)</font>
+            </label>
+            <u32>
+                <halpin>"time-hours"</halpin>
+                <font>("Helvetica",14)</font>
+                <format>"2d"</format>
+            </u32>
+            <label>
+              <text>":"</text>
+              <font>("Helvetica",14)</font>
+            </label>
+            <u32>
+                <halpin>"time-minutes"</halpin>
+                <font>("Helvetica",14)</font>
+                <format>"2d"</format>
+            </u32>
+            <label>
+              <text>":"</text>
+              <font>("Helvetica",14)</font>
+            </label>
+            <u32>
+                <halpin>"time-seconds"</halpin>
+                <font>("Helvetica",14)</font>
+                <format>"2d"</format>
+            </u32>
+            </hbox> </pyvcp>
+
+          In your post-gui.hal file you might use the following to connect it up
+
+           loadrt time
+           loadrt not
+           addf time.0 servo-thread
+           addf not.0 servo-thread
+           net prog-running not.0.in <= halui.program.is-idle
+           net cycle-timer time.0.start <= not.0.out
+           net cycle-seconds pyvcp.time-seconds <= time.0.seconds
+           net cycle-minutes pyvcp.time-minutes <= time.0.minutes
+           net cycle-hours pyvcp.time-hours <= time.0.hours
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+FUNCTIONS
+
+-----------------------------------------------------------------------
+   time.N.funct
+          ( OR <newinstname>.funct (requires a floating-point thread) )
+-----------------------------------------------------------------------
+
+PINS
+
+------------------------------------------------
+   time.N.start  bit in
+          ( OR <newinstname>.start  bit in  )
+
+
+   Timer On
+
+   time.N.seconds  u32 out
+          ( OR <newinstname>.seconds  u32 out  )
+
+
+   Seconds
+
+   time.N.minutes  u32 out
+          ( OR <newinstname>.minutes  u32 out  )
+
+
+   Minutes
+
+   time.N.hours  u32 out
+          ( OR <newinstname>.hours  u32 out  )
+
+
+   Hours
+------------------------------------------------
+
+AUTHOR
+
+----------------
+   John Thornton
+----------------
+
+LICENSE
+
+------
+   GPL
+------
+
+Machinekit Documentation 2015-11-01 TIME(9)

--- a/machinekit-documentation/components/timedelay.asciidoc
+++ b/machinekit-documentation/components/timedelay.asciidoc
@@ -1,0 +1,89 @@
+TIMEDELAY(9) HAL Component TIMEDELAY(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+---------------------------------------------------
+   timedelay - The equivalent of a time-delay relay
+---------------------------------------------------
+
+SYNOPSIS
+
+------------
+   timedelay
+------------
+
+USAGE SYNOPSIS
+
+-----------------------------------------------------------------------------------------------
+   loadrt timedelay
+
+   newinst timedelay <newinstname> [ pincount=N | iprefix=prefix ] [instanceparamX=X | argX=X ]
+-----------------------------------------------------------------------------------------------
+
+FUNCTIONS
+
+-----------------------------------------------------------------------
+   timedelay.N.funct
+          ( OR <newinstname>.funct (requires a floating-point thread) )
+-----------------------------------------------------------------------
+
+PINS
+
+----------------------------------------------------------------------------
+   timedelay.N.in  bit in
+          ( OR <newinstname>.in  bit in  )
+
+
+   timedelay.N.out  bit out
+          ( OR <newinstname>.out  bit out  )
+
+
+   Follows the value of in after applying the delays on-delay and off-delay.
+
+   timedelay.N.on-delay  float in (default: 0.5)
+          ( OR <newinstname>.on-delay  float in (default: 0.5) )
+
+
+   The time, in seconds, for which in must be true before out becomes true
+
+   timedelay.N.off-delay  float in (default: 0.5)
+          ( OR <newinstname>.off-delay  float in (default: 0.5) )
+
+
+   The time, in seconds, for which in must be false before out becomes false
+
+   timedelay.N.elapsed  float out
+          ( OR <newinstname>.elapsed  float out  )
+
+
+   Current value of the internal timer
+----------------------------------------------------------------------------
+
+AUTHOR
+
+-----------------------------------------------------------------------
+   Jeff Epler, based on works by Stephen Wille Padnos and John Kasunich
+-----------------------------------------------------------------------
+
+LICENSE
+
+------
+   GPL
+------
+
+Machinekit Documentation 2015-11-01 TIMEDELAY(9)

--- a/machinekit-documentation/components/toggle.asciidoc
+++ b/machinekit-documentation/components/toggle.asciidoc
@@ -1,0 +1,73 @@
+TOGGLE(9) HAL Component TOGGLE(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+----------------------------------------------------------
+   toggle - 'push-on, push-off' from momentary pushbuttons
+----------------------------------------------------------
+
+SYNOPSIS
+
+---------
+   toggle
+---------
+
+USAGE SYNOPSIS
+
+--------------------------------------------------------------------------------------------
+   loadrt toggle
+
+   newinst toggle <newinstname> [ pincount=N | iprefix=prefix ] [instanceparamX=X | argX=X ]
+--------------------------------------------------------------------------------------------
+
+FUNCTIONS
+
+-------------------------------------
+   toggle.N.funct
+          ( OR <newinstname>.funct  )
+-------------------------------------
+
+PINS
+
+------------------------------------------------------------
+   toggle.N.in  bit in
+          ( OR <newinstname>.in  bit in  )
+
+
+   button input
+
+   toggle.N.out  bit io
+          ( OR <newinstname>.out  bit io  )
+
+
+   on/off output
+
+   toggle.N.debounce  u32 io (default: 2)
+          ( OR <newinstname>.debounce  u32 io (default: 2) )
+
+
+   debounce delay in periods
+------------------------------------------------------------
+
+LICENSE
+
+------
+   GPL
+------
+
+Machinekit Documentation 2015-11-01 TOGGLE(9)

--- a/machinekit-documentation/components/toggle2nist.asciidoc
+++ b/machinekit-documentation/components/toggle2nist.asciidoc
@@ -1,0 +1,79 @@
+TOGGLE2NIST(9) HAL Component TOGGLE2NIST(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+--------------------------------------------
+   toggle2nist - toggle button to nist logic
+--------------------------------------------
+
+SYNOPSIS
+
+--------------
+   toggle2nist
+--------------
+
+USAGE SYNOPSIS
+
+-------------------------------------------------------------------------------------------------
+   loadrt toggle2nist
+
+   newinst toggle2nist <newinstname> [ pincount=N | iprefix=prefix ] [instanceparamX=X | argX=X ]
+-------------------------------------------------------------------------------------------------
+
+DESCRIPTION
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+          toggle2nist  can be used with a momentary push button connected to a toggle component to control a device that has seperate on and off inputs and has an is-on output.  If in changes states via
+          the toggle output
+            If is-on is true then on is false and off is true.
+            If is-on is false the on true and off is false.
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+FUNCTIONS
+
+-----------------------------------------------------------------------
+   toggle2nist.N.funct
+          ( OR <newinstname>.funct (requires a floating-point thread) )
+-----------------------------------------------------------------------
+
+PINS
+
+---------------------------------------------
+   toggle2nist.N.in  bit in
+          ( OR <newinstname>.in  bit in  )
+
+
+   toggle2nist.N.is_on  bit in
+          ( OR <newinstname>.is_on  bit in  )
+
+
+   toggle2nist.N.on  bit out
+          ( OR <newinstname>.on  bit out  )
+
+
+   toggle2nist.N.off  bit out
+          ( OR <newinstname>.off  bit out  )
+---------------------------------------------
+
+LICENSE
+
+------
+   GPL
+------
+
+Machinekit Documentation 2015-11-01 TOGGLE2NIST(9)

--- a/machinekit-documentation/components/tristate_bit.asciidoc
+++ b/machinekit-documentation/components/tristate_bit.asciidoc
@@ -1,0 +1,75 @@
+TRISTATE_BIT(9) HAL Component TRISTATE_BIT(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+-------------------------------------------------------------------------------------------------------------
+   tristate_bit - Place a signal on an I/O pin only when enabled, similar to a tristate buffer in electronics
+-------------------------------------------------------------------------------------------------------------
+
+SYNOPSIS
+
+---------------
+   tristate_bit
+---------------
+
+USAGE SYNOPSIS
+
+--------------------------------------------------------------------------------------------------
+   loadrt tristate_bit
+
+   newinst tristate_bit <newinstname> [ pincount=N | iprefix=prefix ] [instanceparamX=X | argX=X ]
+--------------------------------------------------------------------------------------------------
+
+FUNCTIONS
+
+-------------------------------------
+   tristate_bit.N.funct
+          ( OR <newinstname>.funct  )
+
+   If enable is TRUE, copy in to out.
+-------------------------------------
+
+PINS
+
+----------------------------------------------
+   tristate_bit.N.in_  bit in
+          ( OR <newinstname>.in_  bit in  )
+
+
+   Input value
+
+   tristate_bit.N.out  bit io
+          ( OR <newinstname>.out  bit io  )
+
+
+   Output value
+
+   tristate_bit.N.enable  bit in
+          ( OR <newinstname>.enable  bit in  )
+
+
+   When TRUE, copy in to out
+----------------------------------------------
+
+LICENSE
+
+------
+   GPL
+------
+
+Machinekit Documentation 2015-11-01 TRISTATE_BIT(9)

--- a/machinekit-documentation/components/tristate_float.asciidoc
+++ b/machinekit-documentation/components/tristate_float.asciidoc
@@ -1,0 +1,75 @@
+TRISTATE_FLOAT(9) HAL Component TRISTATE_FLOAT(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+---------------------------------------------------------------------------------------------------------------
+   tristate_float - Place a signal on an I/O pin only when enabled, similar to a tristate buffer in electronics
+---------------------------------------------------------------------------------------------------------------
+
+SYNOPSIS
+
+-----------------
+   tristate_float
+-----------------
+
+USAGE SYNOPSIS
+
+----------------------------------------------------------------------------------------------------
+   loadrt tristate_float
+
+   newinst tristate_float <newinstname> [ pincount=N | iprefix=prefix ] [instanceparamX=X | argX=X ]
+----------------------------------------------------------------------------------------------------
+
+FUNCTIONS
+
+-----------------------------------------------------------------------
+   tristate_float.N.funct
+          ( OR <newinstname>.funct (requires a floating-point thread) )
+
+   If enable is TRUE, copy in to out.
+-----------------------------------------------------------------------
+
+PINS
+
+----------------------------------------------
+   tristate_float.N.in_  float in
+          ( OR <newinstname>.in_  float in  )
+
+
+   Input value
+
+   tristate_float.N.out  float io
+          ( OR <newinstname>.out  float io  )
+
+
+   Output value
+
+   tristate_float.N.enable  bit in
+          ( OR <newinstname>.enable  bit in  )
+
+
+   When TRUE, copy in to out
+----------------------------------------------
+
+LICENSE
+
+------
+   GPL
+------
+
+Machinekit Documentation 2015-11-01 TRISTATE_FLOAT(9)

--- a/machinekit-documentation/components/updown.asciidoc
+++ b/machinekit-documentation/components/updown.asciidoc
@@ -1,0 +1,105 @@
+UPDOWN(9) HAL Component UPDOWN(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+---------------------------------------------------------------------------
+   updown - Counts up or down, with optional limits and wraparound behavior
+---------------------------------------------------------------------------
+
+SYNOPSIS
+
+---------
+   updown
+---------
+
+USAGE SYNOPSIS
+
+--------------------------------------------------------------------------------------------
+   loadrt updown
+
+   newinst updown <newinstname> [ pincount=N | iprefix=prefix ] [instanceparamX=X | argX=X ]
+--------------------------------------------------------------------------------------------
+
+FUNCTIONS
+
+-----------------------------------------------
+   updown.N.funct
+          ( OR <newinstname>.funct  )
+
+   Process inputs and update count if necessary
+-----------------------------------------------
+
+PINS
+
+------------------------------------------------------------------------------------------------------------------------------------------
+   updown.N.countup  bit in
+          ( OR <newinstname>.countup  bit in  )
+
+
+   Increment count when this pin goes from 0 to 1
+
+   updown.N.countdown  bit in
+          ( OR <newinstname>.countdown  bit in  )
+
+
+   Decrement count when this pin goes from 0 to 1
+
+   updown.N.reset  bit in
+          ( OR <newinstname>.reset  bit in  )
+
+
+   Reset count when this pin goes from 0 to 1
+
+   updown.N.count  s32 out
+          ( OR <newinstname>.count  s32 out  )
+
+
+   The current count
+
+   updown.N.clamp  bit io
+          ( OR <newinstname>.clamp  bit io  )
+
+
+   If true, then clamp the output to the min and max parameters.
+
+   updown.N.wrap  bit io
+          ( OR <newinstname>.wrap  bit io  )
+
+
+   If true, then wrap around when the count goes above or below the min and max parameters.  Note that wrap implies (and overrides) clamp.
+
+   updown.N.max  s32 io (default: 0x7FFFFFFF)
+          ( OR <newinstname>.max  s32 io (default: 0x7FFFFFFF) )
+
+
+   If clamp or wrap is set, count will never exceed this number
+
+   updown.N.min  s32 io
+          ( OR <newinstname>.min  s32 io  )
+
+
+   If clamp or wrap is set, count will never be less than this number
+------------------------------------------------------------------------------------------------------------------------------------------
+
+LICENSE
+
+------
+   GPL
+------
+
+Machinekit Documentation 2015-11-01 UPDOWN(9)

--- a/machinekit-documentation/components/wcomp.asciidoc
+++ b/machinekit-documentation/components/wcomp.asciidoc
@@ -1,0 +1,97 @@
+WCOMP(9) HAL Component WCOMP(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+----------------------------
+   wcomp - Window comparator
+----------------------------
+
+SYNOPSIS
+
+--------
+   wcomp
+--------
+
+USAGE SYNOPSIS
+
+-------------------------------------------------------------------------------------------
+   loadrt wcomp
+
+   newinst wcomp <newinstname> [ pincount=N | iprefix=prefix ] [instanceparamX=X | argX=X ]
+-------------------------------------------------------------------------------------------
+
+FUNCTIONS
+
+-----------------------------------------------------------------------
+   wcomp.N.funct
+          ( OR <newinstname>.funct (requires a floating-point thread) )
+-----------------------------------------------------------------------
+
+PINS
+
+----------------------------------------------
+   wcomp.N.in  float in
+          ( OR <newinstname>.in  float in  )
+
+
+   Value being compared
+
+   wcomp.N.min_  float in
+          ( OR <newinstname>.min_  float in  )
+
+
+   Low boundary for comparison
+
+   wcomp.N.max_  float in
+          ( OR <newinstname>.max_  float in  )
+
+
+   High boundary for comparison
+
+   wcomp.N.out  bit out
+          ( OR <newinstname>.out  bit out  )
+
+
+   True if in is strictly between min and max
+
+   wcomp.N.under  bit out
+          ( OR <newinstname>.under  bit out  )
+
+
+   True if in is less than or equal to min
+
+   wcomp.N.over  bit out
+          ( OR <newinstname>.over  bit out  )
+
+
+   True if in is greater than or equal to max
+----------------------------------------------
+
+NOTES
+
+------------------------------------------------
+   If max <= min then the behavior is undefined.
+------------------------------------------------
+
+LICENSE
+
+------
+   GPL
+------
+
+Machinekit Documentation 2015-11-01 WCOMP(9)

--- a/machinekit-documentation/components/wcompn.asciidoc
+++ b/machinekit-documentation/components/wcompn.asciidoc
@@ -1,0 +1,109 @@
+WCOMPN(9) HAL Component WCOMPN(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+-------------------------------------
+   wcompn - N-range window comparator
+-------------------------------------
+
+SYNOPSIS
+
+---------
+   wcompn
+---------
+
+USAGE SYNOPSIS
+
+--------------------------------------------------------------------------------------------
+   loadrt wcompn
+
+   newinst wcompn <newinstname> [ pincount=N | iprefix=prefix ] [instanceparamX=X | argX=X ]
+--------------------------------------------------------------------------------------------
+
+FUNCTIONS
+
+-----------------------------------------------------------------------
+   wcompn.N.funct
+          ( OR <newinstname>.funct (requires a floating-point thread) )
+-----------------------------------------------------------------------
+
+PINS
+
+----------------------------------------------------------------
+   wcompn.N.in  float in
+          ( OR <newinstname>.in  float in  )
+
+
+   Value being compared
+
+   wcompn.N.value#  float in (M=0..pincount)
+          ( OR <newinstname>.value#  float in (M=0..pincount)  )
+
+
+   Boundary N for comparison
+
+   wcompn.N.default_out  s32 in (default: -1)
+          ( OR <newinstname>.default_out  s32 in (default: -1) )
+
+
+   Default output value when input is not in range
+
+   wcompn.N.out  s32 out
+          ( OR <newinstname>.out  s32 out  )
+
+
+   Returns the index of the window the in is currently in
+
+   wcompn.N.under  bit out
+          ( OR <newinstname>.under  bit out  )
+
+
+   True if in is less than value0
+
+   wcompn.N.over  bit out
+          ( OR <newinstname>.over  bit out  )
+
+
+   True if in is greater than or equal to alue<N-1>
+
+   wcompn.N.in_range  bit out
+          ( OR <newinstname>.in_range  bit out  )
+
+
+   True if in is strictly between value0 and value<N-1>
+----------------------------------------------------------------
+
+INST_PARAMETERS
+
+----------------------------
+   pincount int (default: 2)
+----------------------------
+
+NOTES
+
+--------------------------------------------------------------------------------------
+   If max <= min or value<x> are not in ascending orderthen the behavior is undefined.
+--------------------------------------------------------------------------------------
+
+LICENSE
+
+------
+   GPL
+------
+
+Machinekit Documentation 2015-11-01 WCOMPN(9)

--- a/machinekit-documentation/components/weighted_sum.asciidoc
+++ b/machinekit-documentation/components/weighted_sum.asciidoc
@@ -1,0 +1,88 @@
+WEIGHTED_SUM(9) HAL Component WEIGHTED_SUM(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+----------------------------------------------------
+   weighted_sum - Weighted Summer for Machinekit HAL
+----------------------------------------------------
+
+SYNOPSIS
+
+---------------
+   weighted_sum
+---------------
+
+USAGE SYNOPSIS
+
+--------------------------------------------------------------------------------------------------
+   loadrt weighted_sum
+
+   newinst weighted_sum <newinstname> [ pincount=N | iprefix=prefix ] [instanceparamX=X | argX=X ]
+--------------------------------------------------------------------------------------------------
+
+FUNCTIONS
+
+-------------------------------------------------------------------------------------
+   weighted_sum.N.process_wsums.funct
+          ( OR <newinstname>.process_wsums.funct (requires a floating-point thread) )
+-------------------------------------------------------------------------------------
+
+PINS
+
+-------------------------------------------------------------------------------------------------------------------------------------
+   weighted_sum.N.in##  bit in (MM=00..pincount)
+          ( OR <newinstname>.in##  bit in (MM=00..pincount)  )
+
+
+   The ## inputs of weighted summer
+
+   weighted_sum.N.hold  bit in
+          ( OR <newinstname>.hold  bit in  )
+
+
+   When TRUE, the sum output does not change.   When FALSE, the sum output tracks the bit inputs according to the weights and offset.
+
+   weighted_sum.N.sum  s32 out
+          ( OR <newinstname>.sum  s32 out  )
+
+
+   The output of the weighted summer
+
+   weighted_sum.N.weight##  s32 io (MM=00..pincount)
+          ( OR <newinstname>.weight##  s32 io (MM=00..pincount)  )
+
+
+   The weight of the input of weighted summer ##. The default value is 2^m.
+
+   weighted_sum.N.offset  s32 io
+          ( OR <newinstname>.offset  s32 io  )
+-------------------------------------------------------------------------------------------------------------------------------------
+
+INST_PARAMETERS
+
+----------------------------
+   pincount int (default: 8)
+----------------------------
+
+LICENSE
+
+------
+   GPL
+------
+
+Machinekit Documentation 2015-11-01 WEIGHTED_SUM(9)

--- a/machinekit-documentation/components/xor2.asciidoc
+++ b/machinekit-documentation/components/xor2.asciidoc
@@ -1,0 +1,76 @@
+XOR2(9) HAL Component XOR2(9)
+
+INSTANTIABLE COMPONENTS
+
+----------------------------------------------------------------------------------------------------
+   All instantiable components can be loaded in two manners
+
+
+   Using loadrt with or without count= | names= parameters as per legacy components
+
+
+   Using newinst, which names the instance and allows further parameters and arguments,
+
+
+   primarily pincount= which can set the number of pins created for that instance (where applicable)
+----------------------------------------------------------------------------------------------------
+
+NAME
+
+-------------------------------------------
+   xor2 - Two-input XOR (exclusive OR) gate
+-------------------------------------------
+
+SYNOPSIS
+
+-------
+   xor2
+-------
+
+USAGE SYNOPSIS
+
+------------------------------------------------------------------------------------------
+   loadrt xor2
+
+   newinst xor2 <newinstname> [ pincount=N | iprefix=prefix ] [instanceparamX=X | argX=X ]
+------------------------------------------------------------------------------------------
+
+FUNCTIONS
+
+-------------------------------------
+   xor2.N.funct
+          ( OR <newinstname>.funct  )
+-------------------------------------
+
+PINS
+
+---------------------------------------------------------------------------------
+   xor2.N.in0  bit in
+          ( OR <newinstname>.in0  bit in  )
+
+
+   xor2.N.in1  bit in
+          ( OR <newinstname>.in1  bit in  )
+
+
+   xor2.N.out  bit out
+          ( OR <newinstname>.out  bit out  )
+
+
+   out is computed from the value of in0 and in1 according to the following rule:
+
+          in0=true in1=false
+          in0=false in1=true
+                 out=true
+
+          Otherwise,
+                 out=false
+---------------------------------------------------------------------------------
+
+LICENSE
+
+------
+   GPL
+------
+
+Machinekit Documentation 2015-11-01 XOR2(9)

--- a/machinekit-documentation/developing/writing-components.asciidoc
+++ b/machinekit-documentation/developing/writing-components.asciidoc
@@ -13,6 +13,8 @@ Certainly, maths and logic components are very well catered for.
 
 link:../../src/hal/components.asciidoc[This] is a brief resume of the existing 'stock' components
 
+link:../index-instantiated-components.asciidoc[This] is an index of Instantiated Component man pages
+
 ==  C files
 
 The most powerful and flexible method of writing components, is to write them in C.

--- a/machinekit-documentation/index-HAL.asciidoc
+++ b/machinekit-documentation/index-HAL.asciidoc
@@ -23,6 +23,8 @@ link:../src/hal/parallel_port.asciidoc[Parallel Port]
 
 link:../src/hal/components.asciidoc[HAL Components]
 
+link:index-instantiated-components.asciidoc[HAL Instantiated Component Man Pages]
+
 link:../src/hal/rtcomps.asciidoc[rtcomps]
 
 link:../src/hal/halmodule.asciidoc[halmodule]

--- a/machinekit-documentation/index-instantiated-components.asciidoc
+++ b/machinekit-documentation/index-instantiated-components.asciidoc
@@ -1,0 +1,302 @@
+= Index of Instantiated HAL Components
+
+
+The essential difference between normal realtime components and instantiable components,
+
+is that 'normal components' are loaded once only and have to create as many copies of the
+
+component as they need, all at once, there and then.
+
+
+Instantiable components load the 'base component' and from that can create instances.
+
+of the component whenever they are required.
+
+So instances can be created in separate hal files, on-the-fly or whatever.
+
+Amoungst many advantages, it opens up huge flexibility in configuration.
+
+
+Further info link:../src/hal/new-instantiated-components.asciidoc[here]
+
+
+== The available Instantiated HAL Components are:
+
+
+- link:components/abs.asciidoc[abs]
+
+
+- link:components/abs_s32.asciidoc[abs_s32]
+
+
+- link:components/and2.asciidoc[and2]
+
+
+- link:components/andn.asciidoc[andn]
+
+
+- link:components/at_pid.asciidoc[at_pid]
+
+
+- link:components/bin2gray.asciidoc[bin2gray]
+
+
+- link:components/biquad.asciidoc[biquad]
+
+
+- link:components/bitslice.asciidoc[bitslice]
+
+
+- link:components/bitwise.asciidoc[bitwise]
+
+
+- link:components/bldc_hall3.asciidoc[bldc_hall3]
+
+
+- link:components/blend.asciidoc[blend]
+
+
+- link:components/clarke2.asciidoc[clarke2]
+
+
+- link:components/clarke3.asciidoc[clarke3]
+
+
+- link:components/clarkeinv.asciidoc[clarkeinv]
+
+
+- link:components/comp.asciidoc[comp]
+
+
+- link:components/constant.asciidoc[constant]
+
+
+- link:components/ddt.asciidoc[ddt]
+
+
+- link:components/deadzone.asciidoc[deadzone]
+
+
+- link:components/debounce.asciidoc[debounce]
+
+
+- link:components/div2.asciidoc[div2]
+
+
+- link:components/edge.asciidoc[edge]
+
+
+- link:components/estop_latch.asciidoc[estop_latch]
+
+
+- link:components/feedcomp.asciidoc[feedcomp]
+
+
+- link:components/flipflop.asciidoc[flipflop]
+
+
+- link:components/gantry.asciidoc[gantry]
+
+
+- link:components/gearchange.asciidoc[gearchange]
+
+
+- link:components/gray2bin.asciidoc[gray2bin]
+
+
+- link:components/hbridge.asciidoc[hbridge]
+
+
+- link:components/hypot.asciidoc[hypot]
+
+
+- link:components/idb.asciidoc[idb]
+
+
+- link:components/ilowpass.asciidoc[ilowpass]
+
+
+- link:components/integ.asciidoc[integ]
+
+
+- link:components/invert.asciidoc[invert]
+
+
+- link:components/io_muxn.asciidoc[io_muxn]
+
+
+- link:components/joyhandle.asciidoc[joyhandle]
+
+
+- link:components/knob2float.asciidoc[knob2float]
+
+
+- link:components/latencybins.asciidoc[latencybins]
+
+
+- link:components/led_dim.asciidoc[led_dim]
+
+
+- link:components/lgantry.asciidoc[lgantry]
+
+
+- link:components/limit1.asciidoc[limit1]
+
+
+- link:components/limit2.asciidoc[limit2]
+
+
+- link:components/limit3.asciidoc[limit3]
+
+
+- link:components/lincurve.asciidoc[lincurve]
+
+
+- link:components/lowpass.asciidoc[lowpass]
+
+
+- link:components/lut5.asciidoc[lut5]
+
+
+- link:components/lutn.asciidoc[lutn]
+
+
+- link:components/maj3.asciidoc[maj3]
+
+
+- link:components/match8.asciidoc[match8]
+
+
+- link:components/minmax.asciidoc[minmax]
+
+
+- link:components/mult2.asciidoc[mult2]
+
+
+- link:components/multiclick.asciidoc[multiclick]
+
+
+- link:components/multiswitch.asciidoc[multiswitch]
+
+
+- link:components/mux16.asciidoc[mux16]
+
+
+- link:components/mux2.asciidoc[mux2]
+
+
+- link:components/mux4.asciidoc[mux4]
+
+
+- link:components/mux8.asciidoc[mux8]
+
+
+- link:components/muxn.asciidoc[muxn]
+
+
+- link:components/muxn_u32.asciidoc[muxn_u32]
+
+
+- link:components/near.asciidoc[near]
+
+
+- link:components/neg.asciidoc[neg]
+
+
+- link:components/not.asciidoc[not]
+
+
+- link:components/offset.asciidoc[offset]
+
+
+- link:components/oneshot.asciidoc[oneshot]
+
+
+- link:components/or2.asciidoc[or2]
+
+
+- link:components/orient.asciidoc[orient]
+
+
+- link:components/orn.asciidoc[orn]
+
+
+- link:components/out_to_io.asciidoc[out_to_io]
+
+
+- link:components/pid.asciidoc[pid]
+
+
+- link:components/reset.asciidoc[reset]
+
+
+- link:components/safety_latch.asciidoc[safety_latch]
+
+
+- link:components/sample_hold.asciidoc[sample_hold]
+
+
+- link:components/scale.asciidoc[scale]
+
+
+- link:components/select8.asciidoc[select8]
+
+
+- link:components/selectn.asciidoc[selectn]
+
+
+- link:components/sphereprobe.asciidoc[sphereprobe]
+
+
+- link:components/stats.asciidoc[stats]
+
+
+- link:components/sum2.asciidoc[sum2]
+
+
+- link:components/thc.asciidoc[thc]
+
+
+- link:components/thcud.asciidoc[thcud]
+
+
+- link:components/threadtest.asciidoc[threadtest]
+
+
+- link:components/time.asciidoc[time]
+
+
+- link:components/timedelay.asciidoc[timedelay]
+
+
+- link:components/toggle.asciidoc[toggle]
+
+
+- link:components/toggle2nist.asciidoc[toggle2nist]
+
+
+- link:components/tristate_bit.asciidoc[tristate_bit]
+
+
+- link:components/tristate_float.asciidoc[tristate_float]
+
+
+- link:components/updown.asciidoc[updown]
+
+
+- link:components/wcomp.asciidoc[wcomp]
+
+
+- link:components/wcompn.asciidoc[wcompn]
+
+
+- link:components/weighted_sum.asciidoc[weighted_sum]
+
+
+- link:components/xor2.asciidoc[xor2]
+
+
+=== This listing is manually generated when new components are added or removed
+
+To ensure your copy repo is up to date, do frequent pulls from the machinekit-docs master repo
+

--- a/machinekit-documentation/maintainence/man2asciidoc.sh
+++ b/machinekit-documentation/maintainence/man2asciidoc.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+DOC="index-instantiated-components.asciidoc"
+
+touch $DOC
+echo "= Index of Instantiated HAL Components\n\n" > $DOC
+
+echo "The essential difference between normal realtime components and instantiable components,\n" >> $DOC
+echo "is that 'normal components' are loaded once only and have to create as many copies of the\n" >> $DOC
+echo "component as they need, all at once, there and then.\n\n" >> $DOC
+
+echo "Instantiable components load the 'base component' and from that can create instances.\n" >> $DOC
+echo "of the component whenever they are required.\n" >> $DOC
+echo "So instances can be created in separate hal files, on-the-fly or whatever.\n" >> $DOC
+echo "Amoungst many advantages, it opens up huge flexibility in configuration.\n\n" >> $DOC
+
+echo "Further info link:../src/hal/new-instantiated-components.asciidoc[here]\n\n" >> $DOC
+
+echo "== The available Instantiated HAL Components are:\n\n" >> $DOC
+
+mkdir components
+
+for i in $EMC2_HOME/src/hal/i_components/*.icomp ; do
+    compname=$(basename -s .icomp "$i") ;
+    man $EMC2_HOME/man/man9/$compname.9icomp > $compname.txt ;
+    pandoc -s -S $compname.txt -t asciidoc -o $compname.asciidoc ;
+    mv $compname.asciidoc components/$compname.asciidoc ;
+    rm $compname.txt
+    echo "- link:components/$compname.asciidoc[$compname]\n\n" >> $DOC    
+done
+
+echo "=== This listing is manually generated when new components are added or removed\n" >> $DOC
+
+echo "To ensure your copy repo is up to date, do frequent pulls from the machinekit-docs master repo\n" >> $DOC

--- a/src/hal/components.asciidoc
+++ b/src/hal/components.asciidoc
@@ -15,6 +15,8 @@ To view the information in the man page, in a terminal window type:
 man axis (or perhaps 'man 1 axis' if your system requires it.)
 ----
 
+Now you can also view the Machinekit specific Instantiated Component man pages online
+link:../../machinekit-documentation/index-instantiated-components.asciidoc[Here]
 
 axis:: AXIS Machinekit (The Enhanced Machine Controller) Graphical User Interface.
 axis-remote:: AXIS Remote Interface.


### PR DESCRIPTION
Copy in machinekit-documentation/maintainence/man2asciidoc.sh
Should be run from within RIP shell environment

Mass conversion of all instcomp man pages to asciidoc using same.
Allows on line browsing of components

Generated index document for all generated component docs

Signed-off-by: Mick <arceye@mgware.co.uk>