### PR TITLE
amd64 configure needs explicit options as for now

### DIFF
--- a/machinekit-documentation/developing/machinekit-developing.asciidoc
+++ b/machinekit-documentation/developing/machinekit-developing.asciidoc
@@ -59,8 +59,8 @@ cd src
 ./autogen.sh
 # for the Beaglebone, add --with-platform-beaglebone to ./configure
 # for the Raspberry2, add --with-platform-raspberry to ./configure
-# for PC platforms, no options needed
-./configure
+# for PC platforms, add --with-rt-preempt  --with-posix  --with-xenomai
+./configure  
 make
 sudo make setuid
 


### PR DESCRIPTION
`./configure`  needs explicit options as otherwise Xenomai kernel modules are also built.
Like:
```
  LD [M]  /home/cml/machinekit-build-test/src/objects/xenomai-kernel/3.8-1-xenomai.x86-amd64/wcomp.ko
  LD [M]  /home/cml/machinekit-build-test/src/objects/xenomai-kernel/3.8-1-xenomai.x86-amd64/wcompn.ko
  LD [M]  /home/cml/machinekit-build-test/src/objects/xenomai-kernel/3.8-1-xenomai.x86-amd64/weighted_sum.ko
  LD [M]  /home/cml/machinekit-build-test/src/objects/xenomai-kernel/3.8-1-xenomai.x86-amd64/xhc_hb04_util.ko
  LD [M]  /home/cml/machinekit-build-test/src/objects/xenomai-kernel/3.8-1-xenomai.x86-amd64/xor2.ko
```
That is at least confusing.


Tested on  wheezy:
```
cml@debian-cml2:~/machinekit-build-test$ uname -a
Linux debian-cml2 3.8-1-xenomai.x86-amd64 #1 SMP Debian 3.8.13-9 x86_64 GNU/Linux
cml@debian-cml2:~/machinekit-build-test$ git log | head -5
commit 8bbcdfb0a6e7ffeadcc2553272f4b116581dc1eb
Merge: 1200f35 8305c46
Author: cdsteinkuehler <charles@steinkuehler.net>
Date:   Fri Mar 11 14:30:50 2016 -0600
```