### PR TITLE
Add pkg-config to the list of supporting packages

### DIFF
--- a/machinekit-documentation/developing/machinekit-developing.asciidoc
+++ b/machinekit-documentation/developing/machinekit-developing.asciidoc
@@ -27,7 +27,7 @@ link:../getting-started/installing-packages.asciidoc#configure-apt[here] to do s
 
 [source,bash]
 ----
-sudo apt-get install libczmq-dev python-zmq libjansson-dev \
+sudo apt-get install libczmq-dev python-zmq libjansson-dev pkg-config \
   libwebsockets-dev libxenomai-dev python-pyftpdlib cython bwidget lsb-release
 ----
 


### PR DESCRIPTION
Without `pkg-config`:
```
~/machinekit/src$ ./autogen.sh
configure.ac:30: error: possibly undefined macro: AC_MSG_ERROR
      If this token and others are legitimate, please use m4_pattern_allow.
      See the Autoconf documentation.
configure.ac:92: error: possibly undefined macro: AC_DEFINE
configure.ac:95: error: possibly undefined macro: AC_SUBST
autoreconf: /usr/bin/autoconf failed with exit status: 1
```
Tested on:
```
~/machinekit/src$ uname -a
Linux debian 3.8-1-xenomai.x86-amd64 #1 SMP Debian 3.8.13-12~1jessie~1da x86_64 GNU/Linux
```
See also: http://stackoverflow.com/a/9024469/4599792