### PR TITLE
fix links not detected by linkchecker

### DIFF
--- a/docs/developing/develop-index.asciidoc
+++ b/docs/developing/develop-index.asciidoc
@@ -5,18 +5,18 @@
 
 = Various developing links
 
-- link:/docs/developing[General links inc. setting up the environment]
+- link:/docs/developing/developing[General links inc. setting up the environment]
 
-- link:/docs/machinekit-developing[Specific building from source stuff]
+- link:/docs/developing/machinekit-developing[Specific building from source stuff]
 
-- link:/docs/rtfaults[How to debug rt faults]
+- link:/docs/developing/rtfaults[How to debug rt faults]
 
-- link:/docs/building-rt-preempt-kernel[Building your own rt-preempt kernel]
+- link:/docs/developing/building-rt-preempt-kernel[Building your own rt-preempt kernel]
 
-- link:/docs/rt-kernel-config[The actual kernel config to use as a start for rt-preempt kernel]
+- link:/docs/developing/rt-kernel-config[The actual kernel config to use as a start for rt-preempt kernel]
 
-- link:/docs/writing-components[General info and links re writing components]
+- link:/docs/developing/writing-components[General info and links re writing components]
 
-- link:/docs/toolchangers[Specific info on writing toolchanger components]
+- link:/docs/developing/toolchangers[Specific info on writing toolchanger components]
 
-- link:/docs/CAN-developing[Information on developing using CAN]
+- link:/docs/developing/CAN-developing[Information on developing using CAN]

--- a/docs/documenting/documenting.asciidoc
+++ b/docs/documenting/documenting.asciidoc
@@ -3,7 +3,7 @@
 
 :skip-front-matter:
 
-:imagesdir: /docs/images
+:imagesdir: /docs/documenting/images
 
 = Documenting
 
@@ -34,7 +34,7 @@ above is to link:https://github.com/join[get a Github user account].
 
 - If this is the first time with a freshly forked repo, go to the next point. If
 the original has changed then you probably need to have your fork updated. Read the
-link:/docs/updating-your-fork[updating your fork] instructions.
+link:/docs/documenting/updating-your-fork[updating your fork] instructions.
 
 - click on the file you want to change and edit the contents.
 

--- a/docs/documenting/updating-your-fork.asciidoc
+++ b/docs/documenting/updating-your-fork.asciidoc
@@ -3,7 +3,7 @@
 
 :skip-front-matter:
 
-:imagesdir: /docs/images
+:imagesdir: /docs/documenting/images
 
 = Updating your fork
 


### PR DESCRIPTION
I wish there'd be a way to find out which links are js-generated so they can be submitted to the checker