### PR TITLE
Overhaul the HAL and Developer indexes

### DIFF
--- a/_includes/css/style.css
+++ b/_includes/css/style.css
@@ -533,7 +533,7 @@ pre, code {
   font-size: 14px;
   padding: 0 .5em;
   line-height: 1.8em;
-  background: #FFF2CA;
+  background: #EDEDEDD;
   /*width: 100%;*/
   border-radius: 5px;
 }
@@ -728,16 +728,16 @@ code.option, code.flag, code.filter, code.output {
   padding-left: 50px;
   border-radius: 0 5px 5px 0;
   position: relative;
-  box-shadow: 0 1px 5px rgba(0, 0, 0, .3), inset 0 1px 0 rgba(255,255,255,.2), inset 0 -1px 0 rgba(0,0,0,.3);
-  background: #7e6d42;
+  box-shadow: 0 1px 5px rgba(0, 0, 0, .3), inset 0 1px 0 rgba(0,0,0,.2), inset 0 -1px 0 rgba(255,255,255,.3);
+  background: #88d598;
   background: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/Pgo8c3ZnIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgd2lkdGg9IjEwMCUiIGhlaWdodD0iMTAwJSIgdmlld0JveD0iMCAwIDEgMSIgcHJlc2VydmVBc3BlY3RSYXRpbz0ibm9uZSI+CiAgPGxpbmVhckdyYWRpZW50IGlkPSJncmFkLXVjZ2ctZ2VuZXJhdGVkIiBncmFkaWVudFVuaXRzPSJ1c2VyU3BhY2VPblVzZSIgeDE9IjAlIiB5MT0iMCUiIHgyPSIwJSIgeTI9IjEwMCUiPgogICAgPHN0b3Agb2Zmc2V0PSIwJSIgc3RvcC1jb2xvcj0iIzdlNmQ0MiIgc3RvcC1vcGFjaXR5PSIxIi8+CiAgICA8c3RvcCBvZmZzZXQ9IjEwMCUiIHN0b3AtY29sb3I9IiM1YzRlMzUiIHN0b3Atb3BhY2l0eT0iMSIvPgogIDwvbGluZWFyR3JhZGllbnQ+CiAgPHJlY3QgeD0iMCIgeT0iMCIgd2lkdGg9IjEiIGhlaWdodD0iMSIgZmlsbD0idXJsKCNncmFkLXVjZ2ctZ2VuZXJhdGVkKSIgLz4KPC9zdmc+);
-  background: -moz-linear-gradient(top,  #7e6d42 0%, #5c4e35 100%);
-  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#7e6d42), color-stop(100%,#5c4e35));
-  background: -webkit-linear-gradient(top,  #7e6d42 0%,#5c4e35 100%);
-  background: -o-linear-gradient(top,  #7e6d42 0%,#5c4e35 100%);
-  background: -ms-linear-gradient(top,  #7e6d42 0%,#5c4e35 100%);
-  background: linear-gradient(to bottom,  #7e6d42 0%,#5c4e35 100%);
-  filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#7e6d42', endColorstr='#5c4e35',GradientType=0 );
+  background: -moz-linear-gradient(top,  #88d598 0%, #5c4e35 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#88d598), color-stop(100%,#5c4e35));
+  background: -webkit-linear-gradient(top,  #88d598 0%,#5c4e35 100%);
+  background: -o-linear-gradient(top,  #88d598 0%,#5c4e35 100%);
+  background: -ms-linear-gradient(top,  #88d598 0%,#5c4e35 100%);
+  background: linear-gradient(to bottom,  #88d598 0%,#5c4e35 100%);
+  filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#88d598', endColorstr='#5c4e35',GradientType=0 );
 }
 
 @media (max-width: 568px){

--- a/docs/code/NML_Messages.asciidoc
+++ b/docs/code/NML_Messages.asciidoc
@@ -3,6 +3,7 @@
 
 :skip-front-matter:
 = NML Messages
+:toc:
 
 == EMC OPERATOR
 

--- a/docs/code/Style_Guide.asciidoc
+++ b/docs/code/Style_Guide.asciidoc
@@ -3,6 +3,7 @@
 
 :skip-front-matter:
 = Coding Style
+:toc:
 
 This chapter describes the source code style preferred by the Machinekit team.
 

--- a/docs/common/Glossary.asciidoc
+++ b/docs/common/Glossary.asciidoc
@@ -4,18 +4,19 @@
 :skip-front-matter:
 
 = Glossary
+:toc:
 
 A listing of terms and what they mean. Some terms have a general
 meaning and several additional meanings for users, installers, and
 developers.
 
-Acme Screw::
+== Acme Screw
      (((acme screw)))[[glo:AcmeScrew]] A type of lead-screw that uses an Acme
     thread form. Acme threads have somewhat lower friction and wear than
     simple triangular threads, but ball-screws are lower yet. Most manual
     machine tools use acme lead-screws.
 
-Axis::
+== Axis
      (((axis)))[[glo:Axis]] One of the computer controlled movable parts of the
     machine. For a typical vertical mill, the table is the X axis, the
     saddle is the Y axis, and the quill or knee is the Z axis. Angular
@@ -23,14 +24,14 @@ Axis::
     linear axes relative to the tool are called U, V, and W
     respectively.
 
-Axis(GUI)::
+== Axis(GUI)
      (((GUI))) One of the Graphical User Interfaces available to users of
     Machinekit. It features the modern use of menus and mouse buttons while
     automating and hiding some of the more traditional Machinekit controls. It is
     the only open-source interface that displays the entire tool path as
     soon as a file is opened.
 
-Backlash::
+== Backlash
      (((backlash)))[[glo:Backlash]] The amount of "play" or lost motion that
     occurs when direction is reversed in a lead screw. or other mechanical
     motion driving system. It can result from nuts that are loose on
@@ -42,7 +43,7 @@ Backlash::
     of the sudden increase in chip load on the cutter as the work piece is
     pulled across the backlash distance by the cutting tool.
 
-Backlash Compensation::
+== Backlash Compensation
      (((backlash compensation))) Any technique that attempts to reduce
     the effect of backlash without actually removing it from the mechanical
     system. This is typically done in software in the controller. This can
@@ -52,50 +53,50 @@ Backlash Compensation::
     (think cutting tool pulling on the work piece) are the source of the
     motion.
 
-Ball Screw::
+== Ball Screw
      (((ball screw)))[[glo:Ballscrew]] A type of lead-screw that uses small
     hardened steel balls between the nut and screw to reduce friction.
     Ball-screws have very low friction and backlash, but are usually quite
     expensive.
 
-Ball Nut::
+== Ball Nut
      (((ball nut)))[[glo:Ballnut]] A special nut designed for use with a
     ball-screw. It contains an internal passage to re-circulate the balls
     from one end of the screw to the other.
 
-CNC::
+== CNC
      (((CNC)))[[glo:CNC]] Computer Numerical Control. The general term used to
     refer to computer control of machinery. Instead of a human operator
     turning cranks to move a cutting tool, CNC uses a computer and motors
     to move the tool, based on a part program.
 
-Comp::
+== Comp
      (((comp)))[[glo:comp]] A tool used to build, compile and install Machinekit HAL
     components.
 
-Configuration(n)::
+== Configuration(n)
      A directory containing a set of configuration files. Custom
     configurations are normally saved in the users home/machinekit/configs
     directory. These files include Machinekit's traditional INI file and HAL
     files. A configuration may also contain several general files that
     describe tools, parameters, and NML connections.
 
-Configuration(v)::
+== Configuration(v)
      The task of setting up Machinekit so that it matches the hardware on a
     machine tool.
 
-Coordinate Measuring Machine::
+== Coordinate Measuring Machine
      (((coordinate measuring machine))) A Coordinate Measuring Machine is
     used to make many accurate measurements on parts. These machines can be
     used to create CAD data for parts where no drawings can be found, when
     a hand-made prototype needs to be digitized for moldmaking, or to check
     the accuracy of machined or molded parts.
 
-Display units::
+== Display units
      (((display units))) The linear and angular units used for onscreen
     display.
 
-DRO::
+== DRO
      (((DRO))) A Digital Read Out is a system of position-measuring devices
     attached to the slides of a machine tool, which are connected to a
     numeric display showing the current location of the tool with respect to
@@ -107,7 +108,7 @@ DRO::
     information from the machine, and some use methods similar to a
     resolver which keeps rolling over.
 
-EDM::
+== EDM
      (((EDM))) EDM is a method of removing metal in hard or difficult to
     machine or tough metals, or where rotating tools would not be able to
     produce the desired shape in a cost-effective manner. An excellent
@@ -118,53 +119,53 @@ EDM::
     EDM can make internal corners with a radius only slightly larger
     than the radius on the corner of the sinking electrode.
 
-EMC::
+== EMC
      (((EMC)))[[glo:EMC]] The Enhanced Machine Controller. Initially a NIST
     project. Renamed to Machinekit in 2012.
 
-EMCIO::
+== EMCIO
      (((EMCIO)))[[glo:EMCIO]] The module within Machinekit that handles general
     purpose I/O, unrelated to the actual motion of the axes.
 
-EMCMOT::
+== EMCMOT
      (((EMCMOT)))[[glo:EMCMOT]] The module within Machinekit that handles
     the actual motion of the cutting tool. It runs as a real-time program
     and directly controls the motors.
 
-Encoder::
+== Encoder
      (((encoder)))[[glo:Encoder]] A device to measure position. Usually a
     mechanical-optical device, which outputs a quadrature signal. The
     signal can be counted by special hardware, or directly by the parport
     with Machinekit.
 
-Feed::
+== Feed
      (((feed)))[[glo:Feed]] Relatively slow, controlled motion of the tool used
     when making a cut.
 
-Feed rate::
+== Feed rate
      (((feed rate))) The speed at which a cutting motion occurs.
     In auto or mdi mode, feed rate is commanded using an F word.
     F10 would mean ten machine units per minute.
 
-Feedback::
+== Feedback
      (((feedback)))[[glo:Feedback]] A method (e.g., quadrature encoder signals)
     by which Machinekit receives information about the position of motors
 
-Feedrate Override::
+== Feedrate Override
      (((feedrate override)))[[glo:FeedrateOveride]] A manual, operator controlled
     change in the rate at which the tool moves while cutting. Often used to
     allow the operator to adjust for tools that are a little dull, or
     anything else that requires the feed rate to be “tweaked”.
 
-Floating Point Number::
+== Floating Point Number
     A number that has a decimal point. (12.300) In HAL it is known as float.
 
-G-Code::
+== G-Code
      (((G-Code)))[[glo:G-Code]] The generic term used to refer to the most
     common part programming language. There are several dialects of G-code,
     Machinekit uses RS274/NGC.
 
-GUI::
+== GUI
     [[glo:GUI]](((GUI))) Graphical User Interface.
     General;;
          A type of interface that allows communications between a computer
@@ -176,42 +177,42 @@ GUI::
         operator allowing manipulation of the machine and the corresponding
         controlling program.
 
-HAL::
+== HAL
      (((HAL)))[[glo:HAL]] Hardware Abstraction Layer. At the highest
     level, it is simply a way to allow a number of
     building blocks to be loaded and interconnected to assemble a complex
     system. Many of the building blocks are drivers for hardware devices.
     However, HAL can do more than just configure hardware drivers.
 
-Home::
+== Home
      (((home)))[[glo:Home]] A specific location in the machine's work envelope
     that is used to make sure the computer and the actual machine both
     agree on the tool position.
 
-ini file::
+== ini file
      (((INI)))[[glo:inifile]] A text file that contains most of the information
     that configures Machinekit for a particular machine.
 
-Instance::
+== Instance
      (((Instance)))[[glo:Instance]] One can have an instance of a class or a
     particular object. The instance is the actual object created at
     runtime. In programmer jargon, the Lassie object is an instance of the
     Dog class. 
 
-Joint Coordinates::
+== Joint Coordinates
      (((joint coordinates)))[[glo:Joint_Coordinates]] These specify the angles
     between the individual joints of the machine. See also Kinematics
 
-Jog::
+== Jog
      (((jog))) Manually moving an axis of a machine. Jogging either moves
     the axis a fixed amount for each key-press, or moves the axis at a
     constant speed as long as you hold down the key. In manual mode,
     jog speed can be set from the graphical interface.
 
-kernel-space::
+== kernel-space
     [[glo:kernel-space]] See real-time.
 
-Kinematics::
+== Kinematics
      (((kinematics)))[[glo:Kinematics]] The position relationship between world
     coordinates and joint coordinates of a machine. There are two types of
     kinematics. Forward kinematics is used to calculate world coordinates
@@ -219,33 +220,33 @@ Kinematics::
     purpose. Note that kinematics does not take into account, the forces,
     moments etc. on the machine. It is for positioning only.
 
-Lead-screw::
+== Lead-screw
      (((lead screw)))[[glo:Leadscrew]] An screw that is rotated by a motor to
     move a table or other part of a machine. Lead-screws are usually either
     ball-screws or acme screws, although conventional triangular threaded
     screws may be used where accuracy and long life are not as important as
     low cost.
 
-Machine units::
+== Machine units
      (((machine units))) The linear and angular units used for machine
     configuration. These units are specified and used in the ini file. 
     HAL pins and parameters are also generally in machine units.
 
-MDI::
+== MDI
      (((MDI)))[[glo:MDI]] Manual Data Input. This is a mode of operation where
     the controller executes single lines of G-code as they are typed by the
     operator.
 
-NIST::
+== NIST
      (((NIST)))[[glo:NIST]] National Institute of Standards and Technology.
     An agency of the Department of Commerce in the United States.
 
-NML::
+== NML
      (((NML)))[[glo:NML]] Neutral Message Language provides a mechanism for
      handling multiple types of messages in the same buffer as well as
      simplifying the interface for encoding and decoding buffers in neutral
      format and the configuration mechanism.
-Offsets::
+== Offsets
      (((offsets)))[[glo:Offsets]]
     An arbitrary amount, added to the value of something to make it
     equal to some desired value. For example, gcode programs are
@@ -256,119 +257,119 @@ Offsets::
     Tool offsets can be used to shift the "uncorrected" length
     of a tool to equal that tool's actual length.
 
-Part Program::
+== Part Program
      (((part Program)))[[glo:PartProgram]] A description of a part,
     in a language that the controller can understand. For Machinekit,
     that language is RS-274/NGC, commonly known as G-code.
 
-Program Units::
+== Program Units
     (((program units))) The linear and angular units used in a part program.
     The linear program units do not have to be the same as the linear machine units.
     See G20 and G21 for more information. The angular program units are always
     measured in degrees.
 
-Python::
+== Python
      General-purpose, very high-level programming language. Used in Machinekit
     for the Axis GUI, the Stepconf configuration tool, and several G-code
     programming scripts.
 
-Rapid::
+== Rapid
      (((rapid)))[[glo:Rapid]] Fast, possibly less precise motion of the tool,
     commonly used to move between cuts. If the tool meets the workpiece
     or the fixturing during a rapid, it is probably a bad thing!
 
-Rapid rate::
+== Rapid rate
      (((rapid rate)))[[glo:RapidRate]]The speed at which a rapid motion occurs.
     In auto or mdi mode, rapid rate is usually the maximum speed of the machine.
     It is often desirable to limit the rapid rate when
     testing a g-code program for the first time.
 
-Real-time::
+== Real-time
     (((real-time)))[[glo:real-time]] Software that is intended to meet
     very strict timing deadlines. Under Linux, in order to meet these
     requirements it is necessary to install a realtime kernel such
     as RTAI and build the software to run in the special real-time
     environment. For this reason real-time software runs in kernel-space.
 
-RTAI::
+== RTAI
      (((RTAI)))[[glo:RTAI]] Real Time Application Interface, see
     https://www.rtai.org/[https://www.rtai.org/], the real-time extensions
     for Linux that Machinekit can use to achieve real-time performance.
 
-RTLINUX::
+== RTLINUX
     (((RTLINUX)))[[glo:RTLINUX]] See
     https://en.wikipedia.org/wiki/RTLinux[https://en.wikipedia.org/wiki/RTLinux],
     an older real-time extension for Linux that Machinekit used to use to
     achieve real-time performance.  Obsolete, replaced by RTAI.
 
-RTAPI::
+== RTAPI
      (((RTAPI)))A portable interface to real-time operating systems
     including RTAI and RTLINUX
 
-RS-274/NGC::
+== RS-274/NGC
      (((RS274NGC)))[[glo:RS274NGC]] The formal name for the language
     used by Machinekit part programs.
 
-Servo Motor::
+== Servo Motor
      (((servo motor)))[[glo:ServoMotor]] Generally, any motor that is used
     with error-sensing feedback to correct the position of an actuator.
     Also, a motor which is specially-designed to provide improved
     performance in such applications.
 
-Servo Loop::
+== Servo Loop
      (((loop)))[[glo:ServoLoop]] A control loop used to control position or
     velocity of an motor equipped with a feedback device.
 
-Signed Integer::
+== Signed Integer
      (((Signed Integer))) A whole number that can have a positive or
     negative sign. In HAL it is known as s32. (A signed 32-bit 
     integer has a usable range of -2,147,483,647 to +2,147,483,647.)
 
-Spindle::
+== Spindle
      (((spindle)))[[glo:Spindle]] The part of a machine tool that spins
     to do the cutting. On a mill or drill, the spindle holds the
     cutting tool. On a lathe, the spindle holds the workpiece.
 
-Spindle Speed Override::
+== Spindle Speed Override
      A manual, operator controlled change in the rate at which the tool
     rotates while cutting. Often used to allow the operator to adjust for
     chatter caused by the cutter's teeth. Spindle Speed Override assumes
     that the Machinekit software has been configured to control spindle speed.
 
-Stepconf::
+== Stepconf
      An Machinekit configuration wizard. It is able to handle many
     step-and-direction motion command based machines. It writes a full
     configuration after the user answers a few questions about the computer
     and machine that Machinekit is to run on.
 
-Stepper Motor::
+== Stepper Motor
      (((stepper motor)))[[glo:StepperMotor]] A type of motor that turns in
     fixed steps. By counting steps, it is possible to determine how far the
     motor has turned. If the load exceeds the torque capability of the
     motor, it will skip one or more steps, causing position errors.
 
-TASK::
+== TASK
      (((TASK)))[[glo:TASK]] The module within Machinekit that coordinates
     the overall execution and interprets the part program.
 
-Tcl/Tk::
+== Tcl/Tk
      (((Tk)))[[glo:Tcl/Tk]] A scripting language and graphical widget toolkit
     with which several of Machinekits GUIs and selection wizards were
     written.
 
-Traverse Move::
+== Traverse Move
      (((Traverse Move))) A move in a straight line from the start point to
     the end point.
 
-Units::
+== Units
     (((units))) See "Machine Units", "Display Units", or "Program Units".
 
-Unsigned Integer::
+== Unsigned Integer
      (((Unsigned Integer))) A whole number that has no sign. In HAL 
     it is known as u32. (An unsigned 32-bit integer has a usable range of
     zero to 4,294,967,296.)
 
-World Coordinates::
+== World Coordinates
      (((world coordinates)))[[glo:World_Coordinates]] This is the absolute
     frame of reference. It gives coordinates in terms of a fixed reference
     frame that is attached to some point (generally the base) of the

--- a/docs/common/Linux_FAQ.asciidoc
+++ b/docs/common/Linux_FAQ.asciidoc
@@ -4,7 +4,7 @@
 :skip-front-matter:
 
 = Linux FAQ 
-
+:toc:
 [[cha:linux-faq]] (((Linux FAQ)))
 
 These are some basic Linux commands and techniques for new to Linux

--- a/docs/common/System_Requirements.asciidoc
+++ b/docs/common/System_Requirements.asciidoc
@@ -23,7 +23,7 @@ absolute minimum but will give reasonable performance for most stepper
 systems.
 
 * 1.2 GHz x86 processor
-* 512 MB RAM up to 2 GB recommended
+* 1GB RAM minimum recommended
 * 8 GB hard disk space minimum
 * Graphics card capable of at least 1024x768 resolution, which is not
    using the NVidia or ATI fglrx proprietary drivers, and which is not an

--- a/docs/common/User_Concepts.asciidoc
+++ b/docs/common/User_Concepts.asciidoc
@@ -6,7 +6,7 @@
 :imagesdir: /docs/common/images
 
 = Important User Concepts
-
+:toc:
 [[cha:important-user-concepts]] (((User Concepts)))
 
 This chapter covers important user concepts that should be understood

--- a/docs/common/user_intro.asciidoc
+++ b/docs/common/user_intro.asciidoc
@@ -6,7 +6,7 @@
 :imagesdir: /docs/common/images
 
 = Machinekit User Introduction
-
+:toc:
 [[cha:machinekit-user-introduction]] (((Machinekit User Introduction)))
 
 == This Manual

--- a/docs/config/copy_and_run.asciidoc
+++ b/docs/config/copy_and_run.asciidoc
@@ -40,7 +40,7 @@ without showing the Configuration Selector screen.
 
 When you select a configuration from the Sample Configurations section, 
 it will automaticly place a copy of that config in the
-emc/configs directory. 
+~/machinekit/configs directory. 
 
 == Next steps in configuration
 

--- a/docs/config/pncconf.asciidoc
+++ b/docs/config/pncconf.asciidoc
@@ -6,7 +6,7 @@
 :imagesdir: /docs/config/images
 
 = Mesa Configuration Wizard
-
+:toc:
 [[cha:PNCconf-wizard]]
 (((Point n Click Configuration Wizard)))
 (((Mesa Configuration Wizard)))

--- a/docs/config/stepconf.asciidoc
+++ b/docs/config/stepconf.asciidoc
@@ -6,7 +6,7 @@
 :imagesdir: /docs/config/images
 
 = Stepper Configuration Wizard
-
+:toc:
 [[cha:stepconf-wizard]] (((Stepconf Wizard)))
 
 Machinekit is capable of controlling a wide range of machinery 

--- a/docs/drivers/AX5214H.asciidoc
+++ b/docs/drivers/AX5214H.asciidoc
@@ -4,7 +4,7 @@
 :skip-front-matter:
 
 = AX5214H Driver
-
+:toc:
 [[cha:ax5214-driver]] (((AX5214H Driver)))
 
 The Axiom Measurement & Control AX5214H is a 48 channel digital I/O

--- a/docs/drivers/GM.asciidoc
+++ b/docs/drivers/GM.asciidoc
@@ -6,7 +6,7 @@
 :imagesdir: /docs/drivers/images
 
 = General Mechatronics Driver
-
+:toc:
 [[cha:gm-driver]] (((General Mechatronics Driver)))
 
 General Mechatronics GM6-PCI card based motion control system

--- a/docs/drivers/GS2.asciidoc
+++ b/docs/drivers/GS2.asciidoc
@@ -4,7 +4,7 @@
 :skip-front-matter:
 
 = GS2 VFD Driver
-
+:toc:
 [[cha:gs2-vfd-driver]] (((GS2 VFD Driver)))
 
 This is a userspace HAL program for the GS2 series of VFD's at

--- a/docs/drivers/VFS11.asciidoc
+++ b/docs/drivers/VFS11.asciidoc
@@ -4,7 +4,7 @@
 :skip-front-matter:
 
 = VFS11 VFD Driver
-
+:toc:
 
 :ini: {basebackend@docbook:'':ini}
 :hal: {basebackend@docbook:'':hal}

--- a/docs/drivers/hal_arm335xQEP.asciidoc
+++ b/docs/drivers/hal_arm335xQEP.asciidoc
@@ -4,7 +4,7 @@
 :skip-front-matter:
 
 = arm355x eQEP encoder driver
-
+:toc:
 [[cha:arm355xQEP-driver]] (((arm335x eQEP driver)))
 
 hal_arm335xQEP is a driver for the 3 hardware quadrature decoders

--- a/docs/drivers/hostmot2.asciidoc
+++ b/docs/drivers/hostmot2.asciidoc
@@ -6,7 +6,7 @@
 :imagesdir: /docs/drivers/images
 
 = Mesa HostMot2 Driver 
-
+:toc:
 [[cha:mesa-hostmot2-driver]] (((Mesa HostMot2 Driver)))
 
 == Introduction 

--- a/docs/drivers/motenc.asciidoc
+++ b/docs/drivers/motenc.asciidoc
@@ -4,7 +4,7 @@
 :skip-front-matter:
 
 = Motenc Driver
-
+:toc:
 [[cha:montec-driver]] (((Motenc Driver)))
 
 Vital Systems Motenc-100 and Motenc-LITE

--- a/docs/drivers/opto22.asciidoc
+++ b/docs/drivers/opto22.asciidoc
@@ -4,7 +4,7 @@
 :skip-front-matter:
 
 = Opto22 Driver
-
+:toc:
 [[cha:opto22-driver]] (((Opto22 Driver)))
 
 PCI AC5 ADAPTER CARD / HAL DRIVER

--- a/docs/drivers/pico_ppmc.asciidoc
+++ b/docs/drivers/pico_ppmc.asciidoc
@@ -6,7 +6,7 @@
 :imagesdir: /docs/drivers/images
 
 = Pico Drivers
-
+:toc:
 [[cha:pico-drivers]] (((Pico PPMC Driver)))
 
 Pico Systems has a family of boards for doing analog servo, stepper,

--- a/docs/drivers/pluto_p.asciidoc
+++ b/docs/drivers/pluto_p.asciidoc
@@ -6,7 +6,7 @@
 :imagesdir: /docs/drivers/images
 
 = Pluto P Driver
-
+:toc:
 [[cha:pluto-p-driver]] (((Pluto P Driver)))
 
 == General Info

--- a/docs/drivers/servo_to_go.asciidoc
+++ b/docs/drivers/servo_to_go.asciidoc
@@ -4,7 +4,7 @@
 :skip-front-matter:
 
 = Servo To Go Driver
-
+:toc:
 [[cha:servo-to-go-driver]] (((Servo To Go Driver)))
 
 The Servo-To-Go (STG) is one of the first PC motion control cards supported

--- a/docs/drivers/shuttlexpress.asciidoc
+++ b/docs/drivers/shuttlexpress.asciidoc
@@ -4,7 +4,7 @@
 :skip-front-matter:
 
 = ShuttleXpress
-
+:toc:
 [[cha:shuttlexpress]] (((ShuttleXpress)))
 
 == Description

--- a/docs/gcode/coordinates.asciidoc
+++ b/docs/gcode/coordinates.asciidoc
@@ -6,7 +6,7 @@
 :imagesdir: /docs/gcode/images
 
 = Coordinate System
-
+:toc:
 [[cha:coordinate-system]] (((Coordinate System)))
 
 == Introduction

--- a/docs/gcode/gcode.asciidoc
+++ b/docs/gcode/gcode.asciidoc
@@ -6,7 +6,7 @@
 :imagesdir: /docs/gcode/images
 
 = G Codes
-
+:toc:
 [[cha:g-codes]] (((G Codes)))
 
 :ini: {basebackend@docbook:'':ini}

--- a/docs/gcode/m-code.asciidoc
+++ b/docs/gcode/m-code.asciidoc
@@ -4,7 +4,7 @@
 :skip-front-matter:
 
 = M Codes
-
+:toc:
 [[cha:m-codes]] (((M Codes)))
 
 :ini: {basebackend@docbook:'':ini}

--- a/docs/gcode/machining_center.asciidoc
+++ b/docs/gcode/machining_center.asciidoc
@@ -4,6 +4,7 @@
 :skip-front-matter:
 
 = CNC Machine Overview
+:toc:
 
 [[cha:cnc-machine-overview]] (((CNC Machine Overview)))
 

--- a/docs/gcode/o-code.asciidoc
+++ b/docs/gcode/o-code.asciidoc
@@ -4,7 +4,7 @@
 :skip-front-matter:
 
 = O Codes
-
+:toc:
 [[cha:O-Codes]] (((O Codes)))
 
 O-codes provide for flow control in NC programs. Each block has an

--- a/docs/gcode/other-code.asciidoc
+++ b/docs/gcode/other-code.asciidoc
@@ -4,7 +4,7 @@
 :skip-front-matter:
 
 = Other Codes
-
+:toc:
 [[cha:other-codes]] (((Other Codes)))
 
 [[sec:F-feed-rate]]

--- a/docs/gcode/overview.asciidoc
+++ b/docs/gcode/overview.asciidoc
@@ -6,7 +6,7 @@
 :imagesdir: /docs/gcode/images
 
 = G Code Overview
-
+:toc:
 [[cha:g-code-overview]] (((G Code Overview)))
 
 :ini: {basebackend@docbook:'':ini}

--- a/docs/gcode/rs274ngc.asciidoc
+++ b/docs/gcode/rs274ngc.asciidoc
@@ -4,7 +4,7 @@
 :skip-front-matter:
 
 = RS274/NGC Differences
-
+:toc:
 [[cha:rs274ngc-programs]] (((RS274/NGC Programs)))
 
 == Changes from RS274/NGC

--- a/docs/gcode/tool_compensation.asciidoc
+++ b/docs/gcode/tool_compensation.asciidoc
@@ -6,7 +6,7 @@
 :imagesdir: /docs/gcode/images
 
 = Tool Compensation
-
+:toc:
 [[cha:tool-compensation]] (((Tool Compensation)))
 
 == Tool Length Offsets

--- a/docs/getting-started/getting-started-platform.asciidoc
+++ b/docs/getting-started/getting-started-platform.asciidoc
@@ -11,26 +11,20 @@ can be some differences in the installation for a specific platform.
 
 [NOTE]
 ====
-You should have a working Debian installation.
+You should first have a working Debian installation.
 ====
 
 == Installation options:
 
 === Images
 
-:leveloffset: +1
+link:../machinekit-images[Machinekit Images]
 
-include::{docdir}/docs/getting-started/machinekit-images.asciidoc[]
-
-:leveloffset: -1
 
 === Installing packages
 
-:leveloffset: +1
+link:../installing-packages[Installing Packages]
 
-include::{docdir}/docs/getting-started/installing-packages.asciidoc[]
-
-:leveloffset: -1
 
 === Development packages
 
@@ -38,5 +32,5 @@ In addition to the configuring of the APT repository, installation of the
 kernel, there are some additional steps to take to install a development
 setup.
 
-. link:/docs/developing/developing[Set up a development platform]
+link:../../developing/developing[Set up a development platform]
   when you want to develop for Machinekit.

--- a/docs/getting-started/installing-packages.asciidoc
+++ b/docs/getting-started/installing-packages.asciidoc
@@ -5,9 +5,10 @@
 
 = Platforms
 
+
 Follow these steps to configure Apt and install a kernel and Machinekit packages:
 
-[WARNING]
+[NOTE]
 ====
 The kernel-naming convention used in these packages may change as
 experience is accumulated, especially with ARM-based systems. Be sure to
@@ -20,11 +21,11 @@ check back here before installing a new kernel.
 
 :leveloffset: +2
 
-include::{docdir}/docs/getting-started/APT-packages-wheezy.asciidoc[]
+- link:../APT-packages-wheezy[APT Packages for Wheezy]
 
-include::{docdir}/docs/getting-started/install-rt-kernel-arm7.asciidoc[]
+- link:../install-rt-kernel-arm7[Install the kernel]
 
-include::{docdir}/docs/getting-started/install-runtime-packages.asciidoc[]
+- link:../install-runtime-packages[Install Runtime Packages]
 
 :leveloffset: -2
 
@@ -32,11 +33,11 @@ include::{docdir}/docs/getting-started/install-runtime-packages.asciidoc[]
 
 :leveloffset: +2
 
-include::{docdir}/docs/getting-started/APT-packages-wheezy.asciidoc[]
+- link:../APT-packages-wheezy[APT Packages for Wheezy]
 
-include::{docdir}/docs/getting-started/install-rt-kernel-i386.asciidoc[]
+- link:../install-rt-kernel-i386[Install the kernel]
 
-include::{docdir}/docs/getting-started/install-runtime-packages.asciidoc[]
+- link:../install-runtime-packages[Install Runtime Packages]
 
 :leveloffset: -2
 
@@ -44,11 +45,11 @@ include::{docdir}/docs/getting-started/install-runtime-packages.asciidoc[]
 
 :leveloffset: +2
 
-include::{docdir}/docs/getting-started/APT-packages-wheezy.asciidoc[]
+- link:../APT-packages-wheezy[APT Packages for Wheezy]
 
-include::{docdir}/docs/getting-started/install-rt-kernel-amd64.asciidoc[]
+- link:../install-rt-kernel-amd64[Install the kernel]
 
-include::{docdir}/docs/getting-started/install-runtime-packages.asciidoc[]
+- link:../install-runtime-packages[Install Runtime Packages]
 
 :leveloffset: -2
 
@@ -57,11 +58,11 @@ include::{docdir}/docs/getting-started/install-runtime-packages.asciidoc[]
 
 :leveloffset: +2
 
-include::{docdir}/docs/getting-started/APT-packages-jessie.asciidoc[]
+- link:../APT-packages-jessie[APT Packages for Jessie]
 
-include::{docdir}/docs/getting-started/install-rt-kernel-arm7.asciidoc[]
+- link:../install-rt-kernel-arm7[Install the kernel]
 
-include::{docdir}/docs/getting-started/install-runtime-packages.asciidoc[]
+- link:../install-runtime-packages[Install Runtime Packages]
 
 :leveloffset: -2
 
@@ -69,11 +70,11 @@ include::{docdir}/docs/getting-started/install-runtime-packages.asciidoc[]
 
 :leveloffset: +2
 
-include::{docdir}/docs/getting-started/APT-packages-jessie.asciidoc[]
+- link:../APT-packages-jessie[APT Packages for Jessie]
 
-include::{docdir}/docs/getting-started/install-rt-kernel-RPi2.asciidoc[]
+- link:../install-rt-kernel-RPi2[Install the kernel]
 
-include::{docdir}/docs/getting-started/install-runtime-packages.asciidoc[]
+- link:../install-runtime-packages[Install Runtime Packages]
 
 :leveloffset: -2
 
@@ -81,11 +82,11 @@ include::{docdir}/docs/getting-started/install-runtime-packages.asciidoc[]
 
 :leveloffset: +2
 
-include::{docdir}/docs/getting-started/APT-packages-jessie.asciidoc[]
+- link:../APT-packages-jessie[APT Packages for Jessie]
 
-include::{docdir}/docs/getting-started/install-rt-kernel-i386.asciidoc[]
+- link:../install-rt-kernel-i386[Install the kernel]
 
-include::{docdir}/docs/getting-started/install-runtime-packages.asciidoc[]
+- link:../install-runtime-packages[Install Runtime Packages]
 
 :leveloffset: -2
 
@@ -93,11 +94,11 @@ include::{docdir}/docs/getting-started/install-runtime-packages.asciidoc[]
 
 :leveloffset: +2
 
-include::{docdir}/docs/getting-started/APT-packages-jessie.asciidoc[]
+- link:../APT-packages-jessie[APT Packages for Jessie]
 
-include::{docdir}/docs/getting-started/install-rt-kernel-amd64.asciidoc[]
+- link:../install-rt-kernel-amd64[Install the kernel]
 
-include::{docdir}/docs/getting-started/install-runtime-packages.asciidoc[]
+- link:../install-runtime-packages[Install Runtime Packages]
 
 :leveloffset: -2
 

--- a/docs/gui/axis.asciidoc
+++ b/docs/gui/axis.asciidoc
@@ -6,7 +6,7 @@
 :imagesdir: /docs/gui/images
 
 = AXIS GUI
-
+:toc:
 [[cha:axis-gui]] (((Axis GUI)))
 
 == Introduction

--- a/docs/gui/gladevcp.asciidoc
+++ b/docs/gui/gladevcp.asciidoc
@@ -6,7 +6,7 @@
 :imagesdir: /docs/gui/images
 
 = Glade Virtual Control Panel
-
+:toc:
 [[cha:glade-vcp]] (((Glade Virtual Control Panel)))
 
 // TODO:

--- a/docs/gui/gmoccapy.asciidoc
+++ b/docs/gui/gmoccapy.asciidoc
@@ -8,7 +8,7 @@
 [[cha:gmoccapy]](((GUI, GMOCCAPY)))
 
 = GMOCCAPY
-
+:toc:
 == Introduction
 
 'GMOCCAPY' is a GUI for LinuxCNC, designed to be used with a touch screen,

--- a/docs/gui/halui.asciidoc
+++ b/docs/gui/halui.asciidoc
@@ -4,7 +4,7 @@
 :skip-front-matter:
 
 = HAL User Interface
-
+:toc:
 [[cha:hal-user-interface]] (((HAL User Interface)))
 
 == Introduction[[sec:HaluiIntroduction]]

--- a/docs/gui/image-to-gcode.asciidoc
+++ b/docs/gui/image-to-gcode.asciidoc
@@ -6,7 +6,7 @@
 :imagesdir: /docs/gui/images
 
 = Image to G Code
-
+:toc:
 [[cha:image-to-g-code]] (((Image to G Code)))
 
 image::image-to-gcode.png[align="center"]

--- a/docs/gui/keystick.asciidoc
+++ b/docs/gui/keystick.asciidoc
@@ -6,7 +6,7 @@
 :imagesdir: /docs/gui/images
 
 = KEYSTICK GUI
-
+:toc:
 [[cha:keystick-gui]] (((KEYSTICK)))
 
 

--- a/docs/gui/mini.asciidoc
+++ b/docs/gui/mini.asciidoc
@@ -6,7 +6,7 @@
 :imagesdir: /docs/gui/images
 
 = MINI GUI
-
+:toc:
 [[cha:mini-gui]] (((Mini GUI)))
 
 == Introduction

--- a/docs/gui/ngcgui.asciidoc
+++ b/docs/gui/ngcgui.asciidoc
@@ -6,7 +6,7 @@
 :imagesdir: /docs/gui/images
 
 = NGCGUI
-
+:toc:
 [[cha:ngcgui]] (((NGCGUI)))
 
 image::ngcgui.png[]

--- a/docs/gui/tklinuxcnc.asciidoc
+++ b/docs/gui/tklinuxcnc.asciidoc
@@ -6,7 +6,7 @@
 :imagesdir: /docs/gui/images
 
 = TkLinuxcnc GUI
-
+:toc:
 [[cha:tklinuxcnc-gui]] (((TkLinuxcnc GUI)))
 
 == Introduction

--- a/docs/gui/tooledit.asciidoc
+++ b/docs/gui/tooledit.asciidoc
@@ -6,7 +6,7 @@
 :imagesdir: /docs/gui/images
 
 = Tool Edit GUI
-
+:toc:
 [[cha:tooledit-gui]] (((Tool Edit GUI)))
 
 == Tool Edit Version Requirements

--- a/docs/gui/touchy.asciidoc
+++ b/docs/gui/touchy.asciidoc
@@ -6,7 +6,7 @@
 :imagesdir: /docs/gui/images
 
 = Touchy GUI
-
+:toc:
 [[cha:touchy-gui]] (((Touchy GUI)))
 
 Touchy is a user interface for Machinekit meant for use on machine control panels,

--- a/docs/hal/basic_hal.asciidoc
+++ b/docs/hal/basic_hal.asciidoc
@@ -7,7 +7,7 @@
 :imagesoutdir: docs/hal/images
 
 = Basic HAL Tutorial
-
+:toc:
 [[cha:basic-hal-tutorial]] (((Basic HAL Tutorial)))
 
 == HAL Commands [[sec:Hal-Commands]]

--- a/docs/hal/canonical-devices.asciidoc
+++ b/docs/hal/canonical-devices.asciidoc
@@ -4,6 +4,7 @@
 :skip-front-matter:
 
 = Canonical Device Interfaces
+:toc:
 
 .Note
 *********************************************************************
@@ -12,6 +13,7 @@ match these specs. Send an email if you spot any problems.
 ********************************************************************* 
 
 [[cha:Canonical-Device-Interfaces]]
+
 == Introduction
 The following sections show the pins, parameters, and functions that 
 are supplied by “canonical devices”. All HAL device drivers should 

--- a/docs/hal/comp.asciidoc
+++ b/docs/hal/comp.asciidoc
@@ -4,6 +4,7 @@
 :skip-front-matter:
 
 = Comp HAL Component Generator
+:toc:
 
 [[cha:comp-hal-component-generator]] (((Comp HAL Component Generator)))
 

--- a/docs/hal/components.asciidoc
+++ b/docs/hal/components.asciidoc
@@ -4,6 +4,7 @@
 :skip-front-matter:
 
 = HAL Components
+:toc:
 
 [[cha:HAL-components]] (((HAL Components)))
 

--- a/docs/hal/general_ref.asciidoc
+++ b/docs/hal/general_ref.asciidoc
@@ -4,6 +4,7 @@
 :skip-front-matter:
 
 = General Reference
+:toc:
 
 [[cha:general-reference]]
 

--- a/docs/hal/hal-examples.asciidoc
+++ b/docs/hal/hal-examples.asciidoc
@@ -6,6 +6,7 @@
 :imagesdir: /docs/hal/images
 
 = HAL Examples
+:toc:
 
 All of these examples assume you are starting with a stepconf based
 configuration and have two threads base-thread and servo-thread. The

--- a/docs/hal/hal-instantiation.asciidoc
+++ b/docs/hal/hal-instantiation.asciidoc
@@ -2,9 +2,11 @@
 ---
 
 :skip-front-matter:
-== What's in the HAl instantiation branch
+= What's in the HAl instantiation branch
+:toc:
 
-=== quick summary
+
+== quick summary
 
 - a backwards-compatible extension of the C HAL API and halcmd and to support
  creation and deletion of components at run time
@@ -13,16 +15,16 @@
 - several migrated and new components
 - demo components for the new features
 
-=== in a nutshell - what can I do with it:
+== in a nutshell - what can I do with it:
 
-==== before you had to know in advance how many copies of a comp you need:
+=== before you had to know in advance how many copies of a comp you need:
 
  loadrt or2 count=2
 
 and that was it, you need one more - go back to the loadrt statement
 and fix it, wherever that was
 
-==== after: create instances as needed
+=== after: create instances as needed
 
 (for the lutn component, see the man page for lut5 - it's just a more
 flexible version of lut5: variable number of pins, and instantiable -
@@ -92,7 +94,7 @@ All hal/i_components have been modified to adhere to this new convention.
 
 legacy vs instantiable: cd field in show comp
 
-=== Overview of changes relevant for developers
+== Overview of changes relevant for developers
 
 - Previously pins, params and functs were owned by components. The API
 functions hence had a 'int comp_id' parameter.
@@ -122,7 +124,7 @@ macros.
 RTAPI_MP_STRING macros. Other types as well as arrays are currently not supported (and
 unlikely to be needed).
 
-=== instantiable component example
+== instantiable component example
 
 Some examples can be found in hal/icomp-example:
 
@@ -130,7 +132,7 @@ Some examples can be found in hal/icomp-example:
 - icomp.c shows all variations of the instantiation API, not all of
    which might be needed for every component
 
-=== HAL userfunct objects
+== HAL userfunct objects
 
 userfuncts are a similar to normal functs, but cannot be addf'd to a thread.
 
@@ -195,7 +197,7 @@ relevant part of machinekit.log:
  Mar 12 21:25:53 nwheezy msgd:0: hal_lib:1768:rt     argv[1] = "bar"
  Mar 12 21:25:53 nwheezy msgd:0: hal_lib:1768:rt     argv[2] = "baz"
 
-=== thread API extensions
+== thread API extensions
 
 This branch also contains work on a generalized thread API, which was
 required for the userfunct feature to work.

--- a/docs/hal/halmodule.asciidoc
+++ b/docs/hal/halmodule.asciidoc
@@ -4,6 +4,8 @@
 :skip-front-matter:
 
 = Creating Userspace Python Components
+:toc:
+
 
 == Basic usage
 

--- a/docs/hal/halshow.asciidoc
+++ b/docs/hal/halshow.asciidoc
@@ -6,6 +6,7 @@
 :imagesdir: /docs/hal/images
 
 = Halshow
+:toc:
 
 [[cha:halshow]] (((Halshow)))
 

--- a/docs/hal/haltcl.asciidoc
+++ b/docs/hal/haltcl.asciidoc
@@ -4,7 +4,7 @@
 :skip-front-matter:
 
 = HAL TCL Files
-
+:toc:
 [[cha:hal-tcl]] (((HAL TCL Files)))
 
 The halcmd language excels in specifiying components and connections but

--- a/docs/hal/halui_examples.asciidoc
+++ b/docs/hal/halui_examples.asciidoc
@@ -2,6 +2,7 @@
 :imagesdir: hal/images
 
 = Halui Examples
+:toc:
 
 For any Halui examples to work you need to add the following line to the [HAL]
 section of the ini file.

--- a/docs/hal/instcomp.asciidoc
+++ b/docs/hal/instcomp.asciidoc
@@ -4,7 +4,7 @@
 :skip-front-matter:
 
 = instcomp HAL Component Generator
-
+:toc:
 [[cha:instcomp-hal-component-generator]] (((instcomp HAL Component Generator)))
 
 == Introduction
@@ -93,7 +93,7 @@ If unnamed the function will be called, *component-name.0.funct*
 
 halcmd allows just the base component name to be added to a thread, to keep existing configs working
 
-So *addf component-name.0 servo-thread* will work
+So *addf component-name servo-thread* will work
 
 What it actually does however is add the *.funct* bit on the end.
 
@@ -128,7 +128,7 @@ eg
 
 then
 
-*'addf somenewcomp8 servo-thread'*
+*'addf somecomp8 servo-thread'*
 
 adds the function to a thread
 
@@ -165,11 +165,11 @@ The reason for this is that kernel module parameters were never envisaged to be 
 Saving a numerical value for use is quite simple, but saving a string which could be any length would involve allocating memory to duplicate it,
 making it a wasteful process and requiring the explicit freeing of that memory when the instance exits.
 
-For this reason, do not use the instanceparam value directly, access it through a copy in the inst_data struct which is named *local[instanceparamname]*
+For this reason, do not use the instanceparam value directly, access it through a copy in the inst_data struct which is named *local_[instanceparamname]*
 
 The most common example is in those components which create variable pin numbers through the 'pincount=NN' parameter.
 
-The 'pincount' value is accessed via *localpincount* in your component function body
+The 'pincount' value is accessed via *local_pincount* in your component function body
 
 See multiswitch and lutn examples below
 

--- a/docs/hal/intro.asciidoc
+++ b/docs/hal/intro.asciidoc
@@ -6,6 +6,7 @@
 :imagesdir: /docs/hal/images
 
 = HAL Introduction
+:toc:
 
 [[cha:hal-introduction]] (((HAL Introduction)))
 

--- a/docs/hal/new-instantiated-components.asciidoc
+++ b/docs/hal/new-instantiated-components.asciidoc
@@ -2,7 +2,8 @@
 ---
 
 :skip-front-matter:
-Using the new Machinekit Instantiated components
+
+= Using the new Machinekit Instantiated components
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 A lot of changes to the codebase have occurred recently, +

--- a/docs/hal/parallel_port.asciidoc
+++ b/docs/hal/parallel_port.asciidoc
@@ -6,7 +6,7 @@
 :imagesdir: /docs/hal/images
 
 = Parallel Port Driver
-
+:toc:
 [[cha:Parport]] (((Parallel Port Driver)))
 
 == Parport

--- a/docs/hal/pyvcp.asciidoc
+++ b/docs/hal/pyvcp.asciidoc
@@ -2,6 +2,7 @@
 :imagesdir: hal/images
 
 = Python Virtual Control Panel
+:toc:
 
 [[cha:pyvcp]] (((Python Virtual Control Panel)))
 

--- a/docs/hal/pyvcp_examples.asciidoc
+++ b/docs/hal/pyvcp_examples.asciidoc
@@ -6,6 +6,8 @@
 :imagesdir: /docs/config/images
 
 = PyVCP Examples
+:toc:
+
 
 == AXIS
 

--- a/docs/hal/rtcomps.asciidoc
+++ b/docs/hal/rtcomps.asciidoc
@@ -6,7 +6,7 @@
 :imagesdir: /docs/hal/images
 
 = HAL Component Descriptions
-
+:toc:
 [[cha:realtime-components]] (((Realtime Components)))
 
 [[sec:Stepgen]]

--- a/docs/hal/tools.asciidoc
+++ b/docs/hal/tools.asciidoc
@@ -6,7 +6,7 @@
 :imagesdir: /docs/hal/images
 
 = HAL Tools
-
+:toc:
 [[cha:hal-tools]] (((HAL Tools)))
 
 == Halcmd[[sec:Halcmd]]

--- a/docs/hal/tutorial.asciidoc
+++ b/docs/hal/tutorial.asciidoc
@@ -6,7 +6,7 @@
 :imagesdir: /docs/hal/images
 
 = Advanced HAL Tutorial
-
+:toc:
 [[cha:HAL-tutorial]] (((HAL Tutorial)))
 
 == Introduction[[sec:Tutorial-Intro]]

--- a/docs/index-HAL.asciidoc
+++ b/docs/index-HAL.asciidoc
@@ -3,39 +3,133 @@
 
 :skip-front-matter:
 
-:toc:
 
-= Hardware Abstract Layer
+= Hardware Abstraction Layer
 
-:toc:
 
+== Using HAL 
 :leveloffset: +1
 
-include::{{page.docs-dir}}/hal/intro.asciidoc[]
+link:../hal/intro[Introduction]
 
-include::{{page.docs-dir}}/hal/basic_hal.asciidoc[]
+- link:../hal/intro#hal-introduction[HAL Introduction]
+  
+- link:../hal/intro#hal-concepts-a-id-sec-hal-concepts-a[HAL Concepts]
+  
+- link:../hal/intro#hal-components-a-id-sec-intro-hal-components-a[HAL Components]
 
-include::{{page.docs-dir}}/hal/tutorial.asciidoc[]
+- link:../hal/intro#timing-issues-in-hal-a-id-sec-timing-issues-a[Timing Issues]
 
-include::{{page.docs-dir}}/hal/hal-examples.asciidoc[]
+link:../hal/basic_hal[Hal Basics]
 
-include::{{page.docs-dir}}/hal/general_ref.asciidoc[]
+- link:../hal/basic_hal#sec:Hal-Commands[HAL Commands]
 
-include::{{page.docs-dir}}/hal/parallel_port.asciidoc[]
+- link:../hal/basic_hal#sec:Hal-Data[HAL Data]
 
-include::{{page.docs-dir}}/hal/rtcomps.asciidoc[]
+- link:../hal/basic_hal#hal-files[HAL Files]
 
-// include::{{page.docs-dir}}/man/man9/index.asciidoc[]
+- link:../hal/basic_hal#hal-components[HAL Components]
 
-include::{{page.docs-dir}}/hal/halmodule.asciidoc[]
+- link:../hal/basic_hal#logic-components[Logic Components]
 
-include::{{page.docs-dir}}/hal/canonical-devices.asciidoc[]
+- link:../hal/basic_hal#conversion-components[Conversion Components]
 
-include::{{page.docs-dir}}/hal/tools.asciidoc[]
+link:../hal/tutorial[Hal Tutorial]
 
-include::{{page.docs-dir}}/hal/halshow.asciidoc[]
+- link:../hal/tutorial#introduction-a-id-sec-tutorial-intro-a[Introduction]
 
-// include::{{page.docs-dir}}/man/man1/index.asciidoc[]
+- link:../hal/tutorial#a-simple-example-a-id-sec-tutorial-simple-example-a[A Simple Example]
+
+- link:../hal/tutorial#halmeter-a-id-sec-tutorial-halmeter-a[Halmeter]
+
+- link:../hal/tutorial#stepgen-example[Stepgen Example]
+
+- link:../hal/tutorial#halscope-a-id-sec-tutorial-halscope-a[Halscope]
+
+link:../hal/hal-examples[Hal Examples]
+
+- link:../hal/hal-examples#manual-toolchange[Manual toolchange]
+
+- link:../hal/hal-examples#compute-velocity[Compute-Velocity]
+
+- link:../hal/hal-examples#soft-start[Soft Start]
+
+- link:../hal/hal-examples#stand-alone-hal[Stand Alone HAL]
+
+link:../hal/general_ref[Hal General reference]
+
+- link:../hal/general_ref#cha:general-reference[General Naming Conventions]
+
+- link:../hal/general_ref#sec:GR-Driver-Naming[Hardware Driver Naming Conventions]
+
+link:../hal/parallel_port[Parallel Port]
+
+- link:../hal/parallel_port#parport[parport]
+
+- link:../hal/parallel_port#sec:probe_parport[probe_parport]
+
+link:../hal/rtcomps[RT components]
+
+- link:../hal/rtcomps#sec:Stepgen[Stepgen]
+
+- link:../hal/rtcomps#sec:PWMgen[PWMgen]
+
+- link:../hal/rtcomps#sec:Encoder[Encoder]
+
+- link:../hal/rtcomps#sec:PID[PID]
+
+- link:../hal/rtcomps#simulated-encoder-a-id-sec-simulated-encoder-a[Simulated Encoder]
+
+- link:../hal/rtcomps#sec:Debounce[Debounce]
+
+- link:../hal/rtcomps#siggen-a-id-sec-siggen-a[Siggen]
+
+- link:../hal/rtcomps#sec:lut5[lut5]
+
+link:../hal/halmodule[Creating Userspace Python Components]
+
+- link:../hal/halmodule#basic-usage[Basic Usage]
+
+- link:../hal/halmodule#userspace-components-and-delays[Userspace Components and Delays]
+
+- link:../hal/halmodule#create-pins-and-parameters[Create pins and parameters]
+
+- link:../hal/halmodule#reading-and-writing-pins-and-parameters[Reading and Writing pins and parameters]
+
+- link:../hal/halmodule#exiting[Exiting]
+
+- link:../hal/halmodule#project-ideas[Project Ideas]
+
+link:../hal/canonical-devices[Canonical devices]
+
+- link:../hal/canonical-devices#cha:Canonical-Device-Interfaces[Introduction]
+
+- link:../hal/canonical-devices#digital-input-a-id-sec-canondigin-a[Digital Input]
+
+- link:../hal/canonical-devices#digital-output-a-id-sec-canondigout-a[Digital Output]
+
+- link:../hal/canonical-devices#analog-input[Analog Input]
+
+- link:../hal/canonical-devices#analog-output[Analog Output]
+
+link:../hal/tools[Tools]
+
+- link:../hal/tools#halcmd-a-id-sec-halcmd-a[Halcmd]
+
+- link:../hal/tools#halmeter-a-id-sec-halmeter-a[Halmeter]
+
+- link:../hal/tools#halscope-a-id-sec-halscope-a[Halscope]
+
+link:../hal/halshow[HalShow]
+
+- link:../hal/halshow#starting-halshow[Starting Halshow]
+
+- link:../hal/halshow#hal-tree-area[HAL Tree area]
+
+- link:../hal/halshow#hal-show-area[HAL Show area]
+
+- link:../hal/halshow#hal-watch-area[HAL Watch area]
+
 
 :leveloffset: -1
 
@@ -43,38 +137,36 @@ include::{{page.docs-dir}}/hal/halshow.asciidoc[]
 
 :leveloffset: +1
 
-link:/docs/developing/writing-components[Writing HAL Components]
+- link:../developing/writing-components[Writing HAL Components]
 
-include::{{page.docs-dir}}/hal/instcomp.asciidoc[]
+- link:../hal/comp[Comp Component Generator]
 
-include::{{page.docs-dir}}/hal/comp.asciidoc[]
-
-// include::{{page.docs-dir}}/man/man3/index.asciidoc[]
+- link:../hal/instcomp[Instcomp Component Generator]
 
 :leveloffset: -1
 
-= Hardware Drivers
+== Hardware Drivers
 
 :leveloffset: +1
 
-include::{{page.docs-dir}}/drivers/AX5214H.asciidoc[]
+- link:../drivers/AX5214H[AX5214H]
 
-include::{{page.docs-dir}}/drivers/GS2.asciidoc[]
+- link:../drivers/GS2[GS2]
 
-include::{{page.docs-dir}}/drivers/VFS11.asciidoc[]
+- link:../drivers/VFS11[VFS11]
 
-include::{{page.docs-dir}}/drivers/hostmot2.asciidoc[]
+- link:../drivers/hostmot2[hostmot2]
 
-include::{{page.docs-dir}}/drivers/motenc.asciidoc[]
+- link:../drivers/motenc[motenc]
 
-include::{{page.docs-dir}}/drivers/opto22.asciidoc[]
+- link:../drivers/opto22[opto22]
 
-include::{{page.docs-dir}}/drivers/pico_ppmc.asciidoc[]
+- link:../drivers/pico_ppmc[pico_ppmc]
 
-include::{{page.docs-dir}}/drivers/pluto_p.asciidoc[]
+- link:../drivers/pluto_p[pluto_p]
 
-include::{{page.docs-dir}}/drivers/servo_to_go.asciidoc[]
+- link:../drivers/servo_to_go[servo_to_go]
 
-include::{{page.docs-dir}}/drivers/GM.asciidoc[]
+- link:../drivers/GM[GM]
 
 :leveloffset: -1

--- a/docs/index-developer.asciidoc
+++ b/docs/index-developer.asciidoc
@@ -3,25 +3,61 @@
 
 :skip-front-matter:
 
-:toc:
-
 = Developer manual
 
-:toc:
 
 == Introduction
 
 :leveloffset: +1
 
-include::{{page.docs-dir}}/code/Code_Notes.asciidoc[]
+link:../code/Code_Notes[Code Notes]
 
-include::{{page.docs-dir}}/code/NML_Messages.asciidoc[]
+- link:../code/Code_Notes#intended-audience[Intended Audience]
 
-include::{{page.docs-dir}}/code/Style_Guide.asciidoc[]
+- link:../code/Code_Notes#organization[Organisation]
 
-include::{{page.docs-dir}}/common/Glossary.asciidoc[]
+- link:../code/Code_Notes#terms-and-definitions[Terms and Definitions]
 
-include::{{page.docs-dir}}/common/GPLD_Copyright.asciidoc[]
+- link:../code/Code_Notes#architecture-overview[Architecture Overview]
+
+- link:../code/Code_Notes#motion-controller-introduction[Motion Controller Introduction]
+
+- link:../code/Code_Notes#block-diagrams-and-data-flow[Block Diagrams]
+
+- link:../code/Code_Notes#commands[Commands]
+
+- link:../code/Code_Notes#backlash-and-screw-error-compensation[Backlash and Screw error Compensation]
+
+- link:../code/Code_Notes#task-controller-emctask[Task Controller EMCTASK]
+
+- link:../code/Code_Notes#io-controller-emcio[IO Controller EMCIO]
+
+- link:../code/Code_Notes#user-interfaces[User Interfaces]
+
+- link:../code/Code_Notes#libnml-introduction[libNML Introduction]
+
+- link:../code/Code_Notes#linkedlist[LinkedList]
+
+- link:../code/Code_Notes#linkedlistnode[LinkedListNode]
+
+- link:../code/Code_Notes#sharedmemory[Shared Memory]
+
+- link:../code/Code_Notes#shmbuffer[SHM Buffer]
+
+- link:../code/Code_Notes#timer[Timer]
+
+- link:../code/Code_Notes#semaphore[Semaphore]
+
+- link:../code/Code_Notes#cms[CMS]
+
+
+link:../code/NML_Messages[NML Messages]
+
+link:../code/Style_Guide[Style Guide]
+
+link:../common/Glossary[Glossary]
+
+link:../common/GPLD_Copyright[GPLD Copyright]
 
 :leveloffset: -1
 

--- a/docs/index-getting-started.asciidoc
+++ b/docs/index-getting-started.asciidoc
@@ -3,31 +3,24 @@
 
 :skip-front-matter:
 
-:toc:
-
-:toclevels: 4
-
 = Getting Started
-
-:toc:
 
 :leveloffset: +1
 
-include::{{page.docs-dir}}/getting-started/getting-started-platform.asciidoc[]
+link:../getting-started/getting-started-platform[Setting up machinekit on a platform]
 
+link:../common/System_Requirements[System Requirements]
 
-include::{{page.docs-dir}}/common/System_Requirements.asciidoc[]
+link:../quickstart/stepper_quickstart[Stepper Quickstart]
 
-include::{{page.docs-dir}}/quickstart/stepper_quickstart.asciidoc[]
+link:../config/stepconf[Stepper Configuration Wizard]
 
-include::{{page.docs-dir}}/config/stepconf.asciidoc[]
+link:../config/pncconf[Mesa Configuration Wizard]
 
-include::{{page.docs-dir}}/config/pncconf.asciidoc[]
+link:../config/copy_and_run[Running Machinekit]
 
-include::{{page.docs-dir}}/config/copy_and_run.asciidoc[]
+link:../common/Linux_FAQ[Linux FAQ]
 
-include::{{page.docs-dir}}/common/Linux_FAQ.asciidoc[]
-
-include::{{page.docs-dir}}/common/GPLD_Copyright.asciidoc[]
+link:../common/GPLD_Copyright[GPLD Copyright]
 
 :leveloffset: -1

--- a/docs/index-user.asciidoc
+++ b/docs/index-user.asciidoc
@@ -3,17 +3,14 @@
 
 :skip-front-matter:
 
-:toc:
+= Machinekit Introduction 
 
-= Machinekit Introduction
-
-:toc:
 
 :leveloffset: +1
 
-include::{{page.docs-dir}}/common/user_intro.asciidoc[]
+- link:../common/user_intro[Introduction]
 
-include::{{page.docs-dir}}/common/User_Concepts.asciidoc[]
+- link:../common/User_Concepts[User Concepts]
 
 :leveloffset: -1
 
@@ -21,21 +18,21 @@ include::{{page.docs-dir}}/common/User_Concepts.asciidoc[]
 
 :leveloffset: +1
 
-include::{{page.docs-dir}}/gui/selector.asciidoc[]
+- link:../gui/selector[Configuration Selector]
 
-include::{{page.docs-dir}}/gui/axis.asciidoc[]
+- link:../gui/axis[Axis]
 
-include::{{page.docs-dir}}/gui/ngcgui.asciidoc[]
+- link:../gui/ngcgui[ngcgui]
 
-include::{{page.docs-dir}}/gui/gmoccapy.asciidoc[]
+- link:../gui/gmoccapy[Gmoccapy]
 
-include::{{page.docs-dir}}/gui/touchy.asciidoc[]
+- link:../gui/touchy[Touchy]
 
-include::{{page.docs-dir}}/gui/tklinuxcnc.asciidoc[]
+- link:../gui/tklinuxcnc[TkLinuxcnc]
 
-include::{{page.docs-dir}}/gui/mini.asciidoc[]
+- link:../gui/mini[Mini]
 
-include::{{page.docs-dir}}/gui/keystick.asciidoc[]
+- link:../gui/keystick[Keystick]
 
 :leveloffset: -1
 
@@ -43,32 +40,32 @@ include::{{page.docs-dir}}/gui/keystick.asciidoc[]
 
 :leveloffset: +1
 
-include::{{page.docs-dir}}/gcode/machining_center.asciidoc[]
+- link:../gcode/machining_center[CNC Machine Overview]
 
-include::{{page.docs-dir}}/gcode/coordinates.asciidoc[]
+- link:../gcode/coordinates[Coordinates]
 
-include::{{page.docs-dir}}/gcode/tool_compensation.asciidoc[]
+- link:../gcode/tool_compensation[Tool Compensation]
 
-include::{{page.docs-dir}}/gcode/overview.asciidoc[]
+- link:../gcode/overview[GCode Overview]
 
-include::{{page.docs-dir}}/gcode/gcode.asciidoc[]
+- link:../gcode/gcode[G Codes]
 
-include::{{page.docs-dir}}/gcode/m-code.asciidoc[]
+- link:../gcode/m-code[M Codes]
 
-include::{{page.docs-dir}}/gcode/o-code.asciidoc[]
+- link:../gcode/o-code[O Codes]
 
-include::{{page.docs-dir}}/gcode/other-code.asciidoc[]
+- link:../gcode/other-code[Other Codes]
 
-include::{{page.docs-dir}}/examples/gcode.asciidoc[]
+- link:../examples/gcode[GCode Examples]
 
-include::{{page.docs-dir}}/lathe/lathe-user.asciidoc[]
+- link:../lathe/lathe-user[Lathe User]
 
-include::{{page.docs-dir}}/gcode/rs274ngc.asciidoc[]
+- link:../gcode/rs274ngc[rs274/NGC differences]
 
-include::{{page.docs-dir}}/gui/image-to-gcode.asciidoc[]
+- link:../gui/image-to-gcode[image2gcode]
 
-include::{{page.docs-dir}}/common/Glossary.asciidoc[]
+- link:../common/Glossary[Glossary]
 
-include::{{page.docs-dir}}/common/GPLD_Copyright.asciidoc[]
+- link:../common/GPLD_Copyright[GPLD Copyright]
 
 :leveloffset: -1

--- a/docs/lathe/lathe-user.asciidoc
+++ b/docs/lathe/lathe-user.asciidoc
@@ -6,7 +6,7 @@
 :imagesdir: /docs/lathe/images
 
 = Lathe User Information
-
+:toc:
 [[cha:lathe-user-information]] (((Lathe User Information)))
 
 This chapter attempts to bring together all the lathe specific

--- a/docs/quickstart/stepper_quickstart.asciidoc
+++ b/docs/quickstart/stepper_quickstart.asciidoc
@@ -6,7 +6,7 @@
 :imagesdir: /docs/quickstart/images
 
 = Stepper Quickstart
-
+:toc:
 [[cha:stepper-quickstart]] (((Stepper Quickstart)))
 
 This section assumes you have done a standard install from the Live


### PR DESCRIPTION
Index document references subsiduary documents as links not includes
Index document does however include TOC for subsiduary documents,
but as links.

Each subsiduary document also has TOC to continue contents visibility
at lower levels no matter how the document was arrived at

Signed-off-by: Mick <arceye@mgware.co.uk>