### PR TITLE
Fix visibility of some [NOTE] banners

### DIFF
--- a/docs/common/starting-emc.asciidoc
+++ b/docs/common/starting-emc.asciidoc
@@ -94,14 +94,12 @@ the section and item names given.
 == TWOPASS
 
 [NOTE]
-====
 Twopass parsing of .hal files is retained for backward compatibility.
 It could be removed without notice.
-
 Since the introduction of link:../../hal/new-instantiated-components[Instantiated Components] 
 which can be created at any time during the start up period or even later,
 it has been rendered redundant.
-====
+
 
 Machinekit supports TWOPASS processing of hal configuration files
 that can help in the modularization and readability of hal files.

--- a/docs/drivers/hostmot2.asciidoc
+++ b/docs/drivers/hostmot2.asciidoc
@@ -150,18 +150,15 @@ exported:
     is not available on the 7i43 due to limitations of the EPP bus.) 
 
 [NOTE]
-//__=====================================================================
 The above 'read_gpio' and 'write_gpio' functions should not 
 normally be needed, since the GPIO bits are read and written along 
 with everything else in the standard 'read' and 'write' 
 functions above, which are normally run in the servo thread.
-
 The 'read_gpio' and 'write_gpio' functions were provided in 
 case some very fast (frequently updated) I/O is needed. These 
 functions should be run in the base thread. If you have need for 
 this, please send an email and tell us about it, and what your 
 application is.
-//__=====================================================================
 
 == Pinouts
 

--- a/docs/getting-started/getting-started-platform.asciidoc
+++ b/docs/getting-started/getting-started-platform.asciidoc
@@ -10,9 +10,7 @@ choice. Because of the multi-platform nature of the machinekit project there
 can be some differences in the installation for a specific platform.
 
 [NOTE]
-====
 You should first have a working Debian installation.
-====
 
 == Installation options:
 

--- a/docs/getting-started/installing-packages.asciidoc
+++ b/docs/getting-started/installing-packages.asciidoc
@@ -9,11 +9,9 @@
 Follow these steps to configure Apt and install a kernel and Machinekit packages:
 
 [NOTE]
-====
 The kernel-naming convention used in these packages may change as
 experience is accumulated, especially with ARM-based systems. Be sure to
 check back here before installing a new kernel.
-====
 
 :sectnums:
 

--- a/docs/gui/ngcgui.asciidoc
+++ b/docs/gui/ngcgui.asciidoc
@@ -122,20 +122,16 @@ may be different.
 
 .Notes
 [NOTE]
-//__===============================
 The demonstration configs create tab pages for just a few of the provided
 examples.  Any gui with a Custom tab page can open any of the library
 example subroutines or any user file if it is in the linuxCNC subroutine
 path.
-
 To see special key bindings, click inside an ngcgui tab page to get
 focus and then presss Control-k.
-
 The demonstration subroutines should run on the simulated
 machine configurations included in the distribution.  A user
 should always understand the behavior and purpose of a program
 before running on a real machine.
-//__===============================
 
 == Library Locations
 

--- a/docs/gui/tooledit.asciidoc
+++ b/docs/gui/tooledit.asciidoc
@@ -10,10 +10,6 @@
 [[cha:tooledit-gui]] (((Tool Edit GUI)))
 
 == Tool Edit Version Requirements
-[NOTE]
-The following configurable features for 'tooledit' are available in versions
-2.5.1 and later. In 2.5.0 the 'tooledit' gui is without the configurable
-features.
 
 image::tooledit.png[align="center",width=640]
 

--- a/docs/hal/basic_hal.asciidoc
+++ b/docs/hal/basic_hal.asciidoc
@@ -141,9 +141,7 @@ A second way to remember this:
 (It sounds silly, but it really helps) is saying this line for 10 times :
 
 [NOTE]
-====
 __net signal source target1 target2__
-====
 
 A pin can be connected to a signal if it obeys the following rules:
 

--- a/docs/hal/parallel_port.asciidoc
+++ b/docs/hal/parallel_port.asciidoc
@@ -31,8 +31,7 @@ outputs, and 9 inputs. In other parallel ports, the control group has
 push-pull drivers and cannot be used as an input.
 
 .HAL and Open Collectors
-[NOTE]
-//__===========================================================
+
 HAL cannot automatically determine if the 'x' mode bidirectional pins
 are actually open collectors (OC). If they are not, they cannot be used
 as inputs, and attempting to drive them LOW from an external source can
@@ -51,7 +50,6 @@ open collector gates (e.g., 74LS05).
 
 On some machines, BIOS settings may affect whether 'x' mode can be
 used. 'SPP' mode is most likely to work.
-//__===========================================================
 
 No other combinations are supported, and a port cannot be changed from
 input to output once the driver is installed. The

--- a/docs/ladder/classic_ladder.asciidoc
+++ b/docs/ladder/classic_ladder.asciidoc
@@ -7,6 +7,7 @@
 
 = Classicladder Programming
 :toc:
+
 [[cha:classicladder-programming]] (((Classicladder Programming)))
 
 == Ladder Concepts

--- a/docs/quickstart/stepper_quickstart.asciidoc
+++ b/docs/quickstart/stepper_quickstart.asciidoc
@@ -139,16 +139,13 @@ So the scale needed is:
 image::step-calc-inch-math.png[align="center"]
 
 [NOTE]
-====
 fix this in the source
-
 latexmath:[ 
 \frac{200 motor steps}{1 motor rev} \times 
 \frac{10 microsteps}{1 motor step} \times
 \frac{2 motor revs}{1 leadscrew rev} \times 
 \frac{1 leadscrew revs}{0.2000 inch} 
 = \frac{20,000 microsteps}{inch} ]
-====
 
 .Units mm
 //__============================================
@@ -171,15 +168,12 @@ So the scale needed is:
 image::step-calc-mm-math.png[align="center"]
 
 [NOTE]
-====
 fix this in the source
-
 latexmath:[ 
 \frac{200 motor steps}{1 motor rev} \times 
 \frac{8 microsteps}{1 motor step} \times
 \frac{3 motor revs}{1 leadscrew rev} \times 
 \frac{1 leadscrew revs}{5.000 mm} 
 = \frac{960 microsteps}{mm} ]
-====
 
 // vim: set syntax=asciidoc:


### PR DESCRIPTION
A peculiar issue with this method of asciidoc to html conversion
in respect of [NOTE]

If the admonition block favoured by asciidoctor is used
```
[NOTE]
====
Text in here
====
```
It will be rendered in a white foreground, which is very difficult to read.

If however it is written as per asciidoc, which the legacy docs are
```
[NOTE]
Text here
```
The text is rendered in a black foreground and easily legible

A third method used in some legacy docs fails to render properly
with everything after a blank line omitted and
back in the page text again
```
[NOTE]
//__=================================
Big block of text

Another block of text
//__================================
```
Various docs edited to make NOTE banners easily legible and ensure
the text intended to be displayed in them is so displayed (unless as in
one case there was so much of it, it was a page section not a note)

Signed-off-by: Mick <arceye@mgware.co.uk>