### PR TITLE
Image path fix in hal docs

### DIFF
--- a/docs/hal/halui_examples.asciidoc
+++ b/docs/hal/halui_examples.asciidoc
@@ -2,7 +2,8 @@
 ---
     
 :skip-front-matter:
-:imagesdir: hal/images
+:imagesdir: /docs/hal/images
+:imagesoutdir: docs/hal/images
 
 = Halui Examples
 :toc:

--- a/docs/hal/pyvcp.asciidoc
+++ b/docs/hal/pyvcp.asciidoc
@@ -2,7 +2,8 @@
 ---
     
 :skip-front-matter:
-:imagesdir: hal/images
+:imagesdir: /docs/hal/images
+:imagesoutdir: docs/hal/images
 
 = Python Virtual Control Panel
 :toc:

--- a/docs/hal/pyvcp_examples.asciidoc
+++ b/docs/hal/pyvcp_examples.asciidoc
@@ -3,7 +3,8 @@
 
 :skip-front-matter:
 
-:imagesdir: /docs/config/images
+:imagesdir: /docs/hal/images
+:imagesoutdir: docs/hal/images
 
 = PyVCP Examples
 :toc:


### PR DESCRIPTION
I fixed missing images by updated the imagesdir and imagesoutdir vars to match known working pages in the docs.