### PR TITLE
Move Search-Bar to primary navigation items for all pages

### DIFF
--- a/_includes/docs_contents.html
+++ b/_includes/docs_contents.html
@@ -5,7 +5,6 @@
     {% include docs_ul.html items=section.docs %}
     {% endfor %}
     {% include sandbox.html %}
-    {% include search-bar.html %}
     {% include edit-me.html %}
   </aside>
 </div>

--- a/_includes/primary-nav-items.html
+++ b/_includes/primary-nav-items.html
@@ -23,4 +23,8 @@
   <li>
     <a href="{{ site.repository }}">GitHub</a>
   </li>
+  <li>
+    {% include search-bar.html %}
+  </li>
+  
 </ul>

--- a/index.html
+++ b/index.html
@@ -43,21 +43,3 @@ overview: true
   </div>
 </section>
 
-<table style="width:100%;table-layout:fixed;overflow:hidden" >
-    <tr>
-    <td bgcolor="#FFFFFF" style="width:40%;"></td>
-        <td bgcolor="#FFFFFF" style="width:30%;">
-        <div class="top-search">
-        <form method="get" id="searchform" id="searchbox_013132401186084955638:hpvljajpulu" action="search-result.html">
-        <div>
-        <input value="013132401186084955638:hpvljajpulu" name="cx" type="hidden"/>
-        <input value="FORID:11" name="cof" type="hidden"/>
-        Search:<BR>
-        <input type="text" value="" name="s" id="s" onfocus="defaultInput(this)" onblur="clearInput(this)" />
-        </div>
-        </form>
-        </div>
-        </td>
-        <td bgcolor="#FFFFFF" style="width:30%;"></td>
-    </tr>
-</table


### PR DESCRIPTION
(top of page)

Remove side bar and front page implementations

Fixes [machinekit/machinekit.github.io] Search Bar on top of page (#60)

Signed-off-by: Mick <arceye@mgware.co.uk>