### PR TITLE
Capitalise and shorten top level header title

### DIFF
--- a/docs/infra/repositories.asciidoc
+++ b/docs/infra/repositories.asciidoc
@@ -5,7 +5,7 @@
 :imagesoutdir: docs/infra/repositories
 
 :toc:
-= git repos & automated build flows
+= Git Repos & Auto Build
 
 There are quite a few
 https://github.com/machinekit[Machinekit git repositories].


### PR DESCRIPTION
Used as menu link in docs sidebar and needed to be shorter