### PR TITLE
Amend docs_contents to exclude from google searches

### DIFF
--- a/_includes/docs_contents.html
+++ b/_includes/docs_contents.html
@@ -1,10 +1,15 @@
-<div class="unit one-fifth hide-on-mobiles">
-  <aside>
-    {% for section in site.data.docs %}
-    <h4>{{ section.title }}</h4>
-    {% include docs_ul.html items=section.docs %}
-    {% endfor %}
-    {% include sandbox.html %}
-    {% include edit-me.html %}
-  </aside>
+<div class="nocontent">
+  <!-- The area to exclude -->
+  <!-- prevent google crawlers adding boiler plate stuff to search hits -->
+    <div class="unit one-fifth hide-on-mobiles">
+      <aside>
+	{% for section in site.data.docs %}
+        <h4>{{ section.title }}</h4>
+	{% include docs_ul.html items=section.docs %}
+        {% endfor %}
+	{% include sandbox.html %}
+        {% include edit-me.html %}
+      </aside>
+    </div>
 </div>
+


### PR DESCRIPTION
Now that searches are fully seeded, there are a lot of hits coming
from crawlers finding 'boiler plate' sidebar links and including
those

eg. Search `HAL` and the `Hal Utilities and GUIs` link keeps appearing.

First stage is to wrapper in a 'nocontent' div

Once in place I can change the cse.xml to activate it and eventually
the crawlers will exclude it on new crawls.

Signed-off-by: Mick <arceye@mgware.co.uk>