### PR TITLE
Move `Edit This Page` and `Sandbox` links to navigation area

### DIFF
--- a/_includes/docs_contents.html
+++ b/_includes/docs_contents.html
@@ -7,8 +7,6 @@
         <h4>{{ section.title }}</h4>
 	{% include docs_ul.html items=section.docs %}
         {% endfor %}
-	{% include sandbox.html %}
-        {% include edit-me.html %}
       </aside>
     </div>
 </div>

--- a/_includes/edit-me.html
+++ b/_includes/edit-me.html
@@ -1,11 +1,10 @@
-
-
-{% if page.edit-path %}
-
-<a href={{page.edit-repo}}/edit/{{page.edit-branch}}/{{page.edit-path}}>Edit this page</a>
-
-{% else %}
-<a href={{page.edit-repo}}/edit/{{page.edit-branch}}/{{page.path}}>Edit this page</a>
-
-{% endif %}
+<div class="unit align-left center-on-mobiles">
+  <p>
+    {% if page.edit-path %}
+	<a href={{page.edit-repo}}/edit/{{page.edit-branch}}/{{page.edit-path}}>Edit this page</a>
+    {% else %}
+	<a href={{page.edit-repo}}/edit/{{page.edit-branch}}/{{page.path}}>Edit this page</a>
+    {% endif %}
+  </p>
+</div>
 

--- a/_includes/primary-nav-items.html
+++ b/_includes/primary-nav-items.html
@@ -26,5 +26,12 @@
   <li>
     {% include search-bar.html %}
   </li>
-  
+  <li>
+    {% include sandbox.html %}
+  </li>
+  <li>
+    {% include edit-me.html %}
+  </li>
 </ul>
+
+

--- a/_includes/sandbox.html
+++ b/_includes/sandbox.html
@@ -1,7 +1,7 @@
 <sandbox>
     <div class="unit align-left center-on-mobiles">
       <p>
-        <a href="http://machinekit.io/docs/sandbox/index.html"> SandBox </a>
+        <a href="http://machinekit.io/docs/sandbox/index.html">SandBox</a>
       </p>
     </div>
 </sandbox>


### PR DESCRIPTION
onto same line as `Search`

The increase in RH sidebar items has pushed these items further down
the page

Moving them makes the layout more coherent, sidebar is for quick access
links to major topics

The navigation list keeps 'Edit this page' in particular, immediately
available and obvious from any page in the site

Signed-off-by: Mick <arceye@mgware.co.uk>