### PR TITLE
Adjusting format

### DIFF
--- a/docs/man/man3/hm2_pktuart_read.asciidoc
+++ b/docs/man/man3/hm2_pktuart_read.asciidoc
@@ -3,8 +3,6 @@
 :skip-front-matter:
 
 = hm2_pktuart_read(3hm2)
-\# Author Boris Skegin
-\# Issued under the terms of the GPL v2 License or any later version
 :manmanual: HAL Components
 :mansource: ../man/man3/hm2_pktuart_read.3hm2.asciidoc
 :man version : 
@@ -12,31 +10,32 @@
 
 == NAME
 
-hm2_pktuart_read -- read data from a Hostmot2 UART buffer
+`*hm2_pktuart_read*` -- read data from a Hostmot2 PktUART buffer
 
 
 
 == SYNTAX
-int hm2_pktuart_read(char *name,  unsigned char data[], u8 *num_frames, u16 *max_frame_length, u16 frame_sizes[])
+`int *hm2_pktuart_read*(char *name,  unsigned char data[], u8 *num_frames, u16 *max_frame_length, u16 frame_sizes[])`
 
 
 
 == DESCRIPTION
-**hm2_pktuart_read** reads data from the PktUART "name".
-"name" is a unique string given to each PktUART during hostmot2 setup. The names of 
-the available channels are printed to standard output during the driver loading 
-process and take the form:
-hm2_<board name>.<board index>.pktuart.<index> For example hm2_5i25.0.pktuart.0
+`*hm2_pktuart_read*` reads data from the PktUART `name`.
+`name` is a unique string given to each PktUART instance during hostmot2 setup.
+The names of the available channels are printed to standard output during
+the driver loading process and take the form:
+`hm2_<board name>.<board index>.pktuart.<index>`.
+For example, *hm2_5i25.0.pktuart.0* .
 
-This function reads a variable number of PktUART packets from the the specified 
+This function reads a variable number of PktUART packets from the specified 
 channel. It should be used inside a realtime HAL component registered with the 
-main hostmot2 driver using the function hm2_pktuart_setup in the setup
+main hostmot2 driver using the function http://www.machinekit.io/docs/man/man3/hm2_pktuart_setup/[`*hm2_pktuart_setup*`] in the setup
 code. 
 
-"(*num_frames)*(*max_frame_length)" should be <= sizeof "data", which one tries
+`(*num_frames) * (*max_frame_length)` should be \<= `sizeof data`, which one tries
 to estimate or guess before calling the function.
-If there are more bytes in the buffer than the size of data array is, then
-RxArraySizeError is returned.
+If there are more bytes in the buffer than the size of `data` array is, then
+`RxArraySizeError` is returned.
 
 Note that the PktUART MaxFrameSize is 1024 bytes as hard-coded in hostmot2.vhd .
 
@@ -46,23 +45,21 @@ Note that the PktUART MaxFrameSize is 1024 bytes as hard-coded in hostmot2.vhd .
 == RETURN VALUE
 Returns the number of bytes read on success and negative error codes on failure.
 
-"num_frames" which pointer is passed by value is set to the number of successfully 
+On return `num_frames` which pointer is passed by value is set to the number of successfully 
 datagrams read.
 
 Negative error codes are:
 
--1 - low level read/write error
+ -1 - low level read/write error
 
--EINVAL - any PktUART configuration error per instance
-
-
+ -EINVAL - any PktUART configuration error per instance
+ 
 
  -110 - RxStartbitError, Rx mode register error
 
  -111 - RxOverrunError, Rx mode register error
 
  -114 - RxRCFIFOError, Rx mode register error
-
 
 
  -1115 - RxPacketOverrrunError, Rx count register error
@@ -73,13 +70,16 @@ Negative error codes are:
 
  -1120 - RxPacketSizeZero, the size of the received packet is zero
 
- -1140 - RxArraySizeError, data array is too small for all the data in the buffer
+ -1140 - RxArraySizeError, total number of bytes is greater  than the size of the *data* array
 
 
 
 
 == SEE ALSO
 
-man hm2_pktuart_setup, man hm2_pktuart_send
+http://www.machinekit.io/docs/man/man3/hm2_pktuart_setup/[`*hm2_pktuart_setup*`]
 
-See src/hal/components/mesa_pktgyro_test.comp for an example usage.
+http://www.machinekit.io/docs/man/man3/hm2_pktuart_send/[`*hm2_pktuart_send*`]
+
+https://github.com/machinekit/machinekit/blob/master/src/hal/components/mesa_pktgyro_test.comp[Example component]
+

--- a/docs/man/man3/hm2_pktuart_read.asciidoc
+++ b/docs/man/man3/hm2_pktuart_read.asciidoc
@@ -15,17 +15,17 @@
 
 
 == SYNTAX
-int *hm2_pktuart_read*(char *name,  unsigned char data[], u8 *num_frames, u16 *max_frame_length, u16 frame_sizes[])
+int *hm2_pktuart_read* (char *name,  unsigned char data[], u8 *num_frames, u16 *max_frame_length, u16 frame_sizes[])
 
 
 
 == DESCRIPTION
-`*hm2_pktuart_read*` reads data from the PktUART `name`. 
+`*hm2_pktuart_read*` reads data from the PktUART `name`. +
 `name` is a unique string given to each PktUART instance during hostmot2 setup.
 The names of the available channels are printed to standard output during
-the driver loading process and take the form:
-`hm2_<board name>.<board index>.pktuart.<index>`.
-For example, *hm2_5i25.0.pktuart.0* .
+the driver loading process and take the form: +
+`hm2_<board name>.<board index>.pktuart.<index>`. +
+For example, _hm2_5i25.0.pktuart.0_ .
 
 This function reads a variable number of PktUART packets from the specified 
 channel. It should be used inside a realtime HAL component registered with the 

--- a/docs/man/man3/hm2_pktuart_read.asciidoc
+++ b/docs/man/man3/hm2_pktuart_read.asciidoc
@@ -73,6 +73,7 @@ Negative error codes are:
  -1140 - RxArraySizeError, the size of the data array is not large enough
  
 {empty} +
+{empty} +
 
 == SEE ALSO
 

--- a/docs/man/man3/hm2_pktuart_read.asciidoc
+++ b/docs/man/man3/hm2_pktuart_read.asciidoc
@@ -70,7 +70,8 @@ Negative error codes are:
 
  -1120 - RxPacketSizeZero, the size of the received packet is zero
 
- -1140 - RxArraySizeError, total number of bytes is greater  than the size of the *data* array
+ -1140 - RxArraySizeError, total number of bytes is greater +
+         than the size of the *data* array is
 
 
 

--- a/docs/man/man3/hm2_pktuart_read.asciidoc
+++ b/docs/man/man3/hm2_pktuart_read.asciidoc
@@ -72,8 +72,7 @@ Negative error codes are:
 
  -1140 - RxArraySizeError, the size of the data array is not large enough
  
-
-
+{empty} +
 
 == SEE ALSO
 

--- a/docs/man/man3/hm2_pktuart_read.asciidoc
+++ b/docs/man/man3/hm2_pktuart_read.asciidoc
@@ -2,7 +2,7 @@
 ---
 :skip-front-matter:
 
-= hm2_pktuart_read(3hm2)
+= hm2_pktuart_read
 :manmanual: HAL Components
 :mansource: ../man/man3/hm2_pktuart_read.3hm2.asciidoc
 :man version : 

--- a/docs/man/man3/hm2_pktuart_read.asciidoc
+++ b/docs/man/man3/hm2_pktuart_read.asciidoc
@@ -15,12 +15,12 @@
 
 
 == SYNTAX
-`int *hm2_pktuart_read*(char *name,  unsigned char data[], u8 *num_frames, u16 *max_frame_length, u16 frame_sizes[])`
+int *hm2_pktuart_read*(char *name,  unsigned char data[], u8 *num_frames, u16 *max_frame_length, u16 frame_sizes[])
 
 
 
 == DESCRIPTION
-`*hm2_pktuart_read*` reads data from the PktUART `name`.
+`*hm2_pktuart_read*` reads data from the PktUART `name`. 
 `name` is a unique string given to each PktUART instance during hostmot2 setup.
 The names of the available channels are printed to standard output during
 the driver loading process and take the form:

--- a/docs/man/man3/hm2_pktuart_read.asciidoc
+++ b/docs/man/man3/hm2_pktuart_read.asciidoc
@@ -70,9 +70,8 @@ Negative error codes are:
 
  -1120 - RxPacketSizeZero, the size of the received packet is zero
 
- -1140 - RxArraySizeError, total number of bytes is greater +
-         than the size of the *data* array is
-
+ -1140 - RxArraySizeError, the size of the *data* array is not large enough
+ 
 
 
 

--- a/docs/man/man3/hm2_pktuart_read.asciidoc
+++ b/docs/man/man3/hm2_pktuart_read.asciidoc
@@ -70,7 +70,7 @@ Negative error codes are:
 
  -1120 - RxPacketSizeZero, the size of the received packet is zero
 
- -1140 - RxArraySizeError, the size of the *data* array is not large enough
+ -1140 - RxArraySizeError, the size of the data array is not large enough
  
 
 


### PR DESCRIPTION
Some pieces of the previous manpage code did not render properly.

Do not know if any *asciidoc* format for functions was agreed upon, so let it be a proposal.