### PR TITLE
Test word wrapping for normal text and code.

### DIFF
--- a/docs/man/man3/hal_pin_new.asciidoc
+++ b/docs/man/man3/hal_pin_new.asciidoc
@@ -22,7 +22,7 @@ int hal_pin_float_new(const char \*__name__, hal_pin_dir_t __dir__, hal_float_t 
 
 int hal_pin_u32_new(const char \*__name__, hal_pin_dir_t __dir__, hal_u32_t ** __data_ptr_addr__, int __comp_id__)
 
-`int hal_pin_s32_new(const char \*__name__, hal_pin_dir_t __dir__, hal_s32_t ** __data_ptr_addr__, int __comp_id__)`
+int hal_pin_s32_new(const char \*__name__, hal_pin_dir_t __dir__, hal_s32_t ** __data_ptr_addr__, int __comp_id__)
 
 int hal_pin_bit_newf(hal_pin_dir_t __dir__, hal_bit_t ** __data_ptr_addr__, int __comp_id__, const char *__fmt__, __...__)
 
@@ -37,10 +37,10 @@ int hal_pin_new(const char *__name__, hal_type_t __type__, hal_in_dir_t __dir__,
 
 
 == ARGUMENTS
-__name__ 
+`__name__`
 The name of the pin
 
-__dir__
+`__dir__`
 The direction of the pin, from the viewpoint of the component.  It may be one
 of **HAL_IN**, **HAL_OUT**, or **HAL_IO**.  Any number of **HAL_IN** or
 **HAL_IO** pins may be connected to the same signal, but at most one
@@ -48,9 +48,9 @@ of **HAL_IN**, **HAL_OUT**, or **HAL_IO**.  Any number of **HAL_IN** or
 is **HAL_OUT** or **HAL_IO**, but may not assign a value to a pin that is
 **HAL_IN**.
 
-__data_ptr_addr__
+`__data_ptr_addr__`
 The address of the pointer-to-data, which must lie within memory allocated by
-`hal_malloc`.
+**hal_malloc**.
 
 `__comp_id__`
 A HAL component identifier returned by an earlier call to **hal_init**.
@@ -58,7 +58,7 @@ A HAL component identifier returned by an earlier call to **hal_init**.
 `__fmt, ...__`
 A printf-style format string and arguments
 
-__type__
+`__type__`
 The type of the param, as specified in **hal_type_t**.
 
 

--- a/docs/man/man3/hal_pin_new.asciidoc
+++ b/docs/man/man3/hal_pin_new.asciidoc
@@ -16,31 +16,31 @@ hal_pin_new -- Create a HAL pin
 
 == SYNTAX
 
- int hal_pin_bit_new(const char *__name__, hal_pin_dir_t __dir__, hal_bit_t ** __data_ptr_addr__, int __comp_id__)
+int hal_pin_bit_new(const char \*__name__, hal_pin_dir_t __dir__, hal_bit_t ** __data_ptr_addr__, int __comp_id__)
 
- int hal_pin_float_new(const char *__name__, hal_pin_dir_t __dir__, hal_float_t ** __data_ptr_addr__, int __comp_id__)
+int hal_pin_float_new(const char \*__name__, hal_pin_dir_t __dir__, hal_float_t ** __data_ptr_addr__, int __comp_id__)
 
- int hal_pin_u32_new(const char *__name__, hal_pin_dir_t __dir__, hal_u32_t ** __data_ptr_addr__, int __comp_id__)
+int hal_pin_u32_new(const char \*__name__, hal_pin_dir_t __dir__, hal_u32_t ** __data_ptr_addr__, int __comp_id__)
 
- int hal_pin_s32_new(const char *__name__, hal_pin_dir_t __dir__, hal_s32_t ** __data_ptr_addr__, int __comp_id__)
+`int hal_pin_s32_new(const char \*__name__, hal_pin_dir_t __dir__, hal_s32_t ** __data_ptr_addr__, int __comp_id__)`
 
- int hal_pin_bit_newf(hal_pin_dir_t __dir__, hal_bit_t ** __data_ptr_addr__, int __comp_id__, const char *__fmt__, __...__)
+int hal_pin_bit_newf(hal_pin_dir_t __dir__, hal_bit_t ** __data_ptr_addr__, int __comp_id__, const char *__fmt__, __...__)
 
- int hal_pin_float_newf(hal_pin_dir_t __dir__, hal_float_t ** __data_ptr_addr__, int __comp_id__, const char *__fmt__, __...__)
+int hal_pin_float_newf(hal_pin_dir_t __dir__, hal_float_t ** __data_ptr_addr__, int __comp_id__, const char *__fmt__, __...__)
 
- int hal_pin_u32_newf(hal_pin_dir_t __dir__, hal_u32_t ** __data_ptr_addr__, int __comp_id__, const char *__fmt__, __...__)
+int hal_pin_u32_newf(hal_pin_dir_t __dir__, hal_u32_t ** __data_ptr_addr__, int __comp_id__, const char *__fmt__, __...__)
 
- int hal_pin_s32_newf(hal_pin_dir_t __dir__, hal_s32_t ** __data_ptr_addr__, int __comp_id__, const char *__fmt__, __...__)
+int hal_pin_s32_newf(hal_pin_dir_t __dir__, hal_s32_t ** __data_ptr_addr__, int __comp_id__, const char *__fmt__, __...__)
 
- int hal_pin_new(const char *__name__, hal_type_t __type__, hal_in_dir_t __dir__, void **__data_ptr_addr__, int __comp_id__)
+int hal_pin_new(const char *__name__, hal_type_t __type__, hal_in_dir_t __dir__, void **__data_ptr_addr__, int __comp_id__)
 
 
 
 == ARGUMENTS
-.IP __name__
+__name__ 
 The name of the pin
-.IP __dir__
 
+__dir__
 The direction of the pin, from the viewpoint of the component.  It may be one
 of **HAL_IN**, **HAL_OUT**, or **HAL_IO**.  Any number of **HAL_IN** or
 **HAL_IO** pins may be connected to the same signal, but at most one
@@ -48,17 +48,17 @@ of **HAL_IN**, **HAL_OUT**, or **HAL_IO**.  Any number of **HAL_IN** or
 is **HAL_OUT** or **HAL_IO**, but may not assign a value to a pin that is
 **HAL_IN**.
 
-.IP __data_ptr_addr__
+__data_ptr_addr__
 The address of the pointer-to-data, which must lie within memory allocated by
-**hal_malloc**.
+`hal_malloc`.
 
-.IP __comp_id__
+`__comp_id__`
 A HAL component identifier returned by an earlier call to **hal_init**.
 
-.IP __fmt, ...__
+`__fmt, ...__`
 A printf-style format string and arguments
 
-.IP __type__
+__type__
 The type of the param, as specified in **hal_type_t**.
 
 


### PR DESCRIPTION
Functions signatures were overrunning before.