### PR TITLE
Correct 'Getting Started' section regards raspbian packages

### DIFF
--- a/docs/getting-started/APT-packages-raspbian.asciidoc
+++ b/docs/getting-started/APT-packages-raspbian.asciidoc
@@ -1,0 +1,17 @@
+---
+---
+
+:skip-front-matter:
+
+= Configure APT for `raspbian`
+
+. Add Machinekit repository
+
+[source,bash]
+----
+sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 43DDF224
+sudo sh -c \
+  "echo 'deb http://deb.machinekit.io/debian raspbian main' > \
+  /etc/apt/sources.list.d/machinekit.list"
+sudo apt-get update
+----

--- a/docs/getting-started/installing-packages.asciidoc
+++ b/docs/getting-started/installing-packages.asciidoc
@@ -68,7 +68,7 @@ check back here before installing a new kernel.
 
 :leveloffset: +2
 
-- link:../APT-packages-jessie[APT Packages for Jessie]
+- link:../APT-packages-raspbian[APT Packages for Raspbian]
 
 - link:../install-rt-kernel-RPi2[Install the kernel]
 


### PR DESCRIPTION
Displays info for setting /etc/apt/sources.list.d/machinekit.list
to the 'jessie' repo

Should be the 'raspbian' repo

As reported by user jtheath@gmail.com

Signed-off-by: Mick <arceye@mgware.co.uk>