### PR TITLE
Further de-troffing and clean up of static manual pages

### DIFF
--- a/docs/man/man1/axis-remote.asciidoc
+++ b/docs/man/man1/axis-remote.asciidoc
@@ -4,7 +4,7 @@
 
 = axis-remote
 :manmanual: HAL Components
-:mansource: ../man/man1/axis-remote.1.asciidoc
+:mansource: ../man/man1/axis-remote.asciidoc
 :man version : 
 
 

--- a/docs/man/man1/axis.asciidoc
+++ b/docs/man/man1/axis.asciidoc
@@ -4,7 +4,7 @@
 
 = AXIS
 :manmanual: HAL Components
-:mansource: ../man/man1/axis.1.asciidoc
+:mansource: ../man/man1/axis.asciidoc
 :man version : 
 
 

--- a/docs/man/man1/comp.asciidoc
+++ b/docs/man/man1/comp.asciidoc
@@ -4,7 +4,7 @@
 
 = comp
 :manmanual: HAL Components
-:mansource: ../man/man1/comp.1.asciidoc
+:mansource: ../man/man1/comp.asciidoc
 :man version : 
 
 

--- a/docs/man/man1/gladevcp.asciidoc
+++ b/docs/man/man1/gladevcp.asciidoc
@@ -4,7 +4,7 @@
 
 = GLADEVCP
 :manmanual: HAL Components
-:mansource: ../man/man1/gladevcp.1.asciidoc
+:mansource: ../man/man1/gladevcp.asciidoc
 :man version : 
 
 

--- a/docs/man/man1/gs2.asciidoc
+++ b/docs/man/man1/gs2.asciidoc
@@ -4,7 +4,7 @@
 
 = gs2_vfd
 :manmanual: HAL Components
-:mansource: ../man/man1/gs2.1.asciidoc
+:mansource: ../man/man1/gs2.asciidoc
 :man version : 
 
 

--- a/docs/man/man1/hal_input.asciidoc
+++ b/docs/man/man1/hal_input.asciidoc
@@ -4,7 +4,7 @@
 
 = HAL_INPUT
 :manmanual: HAL Components
-:mansource: ../man/man1/hal_input.1.asciidoc
+:mansource: ../man/man1/hal_input.asciidoc
 :man version : 
 
 

--- a/docs/man/man1/halcmd.asciidoc
+++ b/docs/man/man1/halcmd.asciidoc
@@ -4,7 +4,7 @@
 
 = HALCMD
 :manmanual: HAL Components
-:mansource: ../man/man1/halcmd.1.asciidoc
+:mansource: ../man/man1/halcmd.asciidoc
 :man version : 
 
 

--- a/docs/man/man1/halmeter.asciidoc
+++ b/docs/man/man1/halmeter.asciidoc
@@ -4,7 +4,7 @@
 
 = HALMETER
 :manmanual: HAL Components
-:mansource: ../man/man1/halmeter.1.asciidoc
+:mansource: ../man/man1/halmeter.asciidoc
 :man version : 
 
 

--- a/docs/man/man1/halrun.asciidoc
+++ b/docs/man/man1/halrun.asciidoc
@@ -5,7 +5,7 @@
 = HALRUN
 
 :manmanual: HAL Components
-:mansource: ../man/man1/halrun.1.asciidoc
+:mansource: ../man/man1/halrun.asciidoc
 :man version : 
 
 

--- a/docs/man/man1/halsampler.asciidoc
+++ b/docs/man/man1/halsampler.asciidoc
@@ -4,7 +4,7 @@
 
 = HALSAMPLER
 :manmanual: HAL Components
-:mansource: ../man/man1/halsampler.1.asciidoc
+:mansource: ../man/man1/halsampler.asciidoc
 :man version : 
 
 

--- a/docs/man/man1/halstreamer.asciidoc
+++ b/docs/man/man1/halstreamer.asciidoc
@@ -4,7 +4,7 @@
 
 = HALSTREAMER
 :manmanual: HAL Components
-:mansource: ../man/man1/halstreamer.1.asciidoc
+:mansource: ../man/man1/halstreamer.asciidoc
 :man version : 
 
 

--- a/docs/man/man1/haltcl.asciidoc
+++ b/docs/man/man1/haltcl.asciidoc
@@ -1,15 +1,15 @@
 ---
 ---
-:skip-front-man1.ter:
+:skip-front-matter:
 
 = HALTCL
 :manmanual: HAL Components
 :mansource: ../man/man1/haltcl.asciidoc
-:man version :.
+:man version:
 
 
 == NAME
-**haltcl** -- man1.ipulate the LinuxCNC HAL from the comman1.d line using a tcl
+**haltcl** -- manipulate the LinuxCNC HAL from the command line using a tcl
 interpeter.
 
 
@@ -20,11 +20,11 @@ interpeter.
 
 
 == DESCRIPTION
-**haltcl** is used to man1.ipulate the HAL (Hardware Abstraction
-Layer) from the comman1.d line using a tcl interpreter. +
+**haltcl** is used to manipulate the HAL (Hardware Abstraction
+Layer) from the command line using a tcl interpreter. +
 
-**haltcl** can optionally read comman1.ds from a file (filename), allowing
-complex HAL configurations to be set up with a single comman1.d.
+**haltcl** can optionally read commands from a file (filename), allowing
+complex HAL configurations to be set up with a single command.
 
 
 
@@ -36,40 +36,40 @@ arrays.  An array is created for each SECTION of the inifile with
 elements for each ITEM in the section.
 [source, bash]
 ----
-       For example, if the inifile contains:
-       [SECTION_A]ITEM.=  1
-       [SECTION_A]ITEM_2 =  2
-       [SECTION_B]ITEM.=.
+For example, if the inifile contains:
+[SECTION_A]ITEM_1 =  1
+[SECTION_A]ITEM_2 =  2
+[SECTION_B]ITEM_1 =  1
 
-       The corresponding tcl variables are:
-       SECTION_A(ITEM. =  1
-       SECTION_A(ITEM_2) =  2
-       SECTION_B(ITEM. =.
+The corresponding tcl variables are:
+SECTION_A(ITEM_1) =  1
+SECTION_A(ITEM_2) =  2
+SECTION_B(ITEM_1) =  1
 ----
 
 **-ini** __inifile__ -- declining usage, use **-i** __inifile__ +
 
 **filename** +
-If specified, the tcl comman1.ds of **filename** are executed.  If no filename
+If specified, the tcl commands of **filename** are executed.  If no filename
 is specified, **haltcl** opens an interactive session.
 
 
 
 == COMMANDS
-**haltcl** includes the comman1.ds of a tcl interpreter augmented with
-comman1.ds for the hal language as described for **halcmd**. +
-The augmented comman1.ds can be listed with the comman1.d:
+**haltcl** includes the commands of a tcl interpreter augmented with
+commands for the hal language as described for **halcmd**. +
+The augmented commands can be listed with the command:
 
 [source, bash]
 ----
-   haltcl: hal --comman1.ds
+haltcl: hal --commands
 
-   addf alias delf delsig getp gets ptype stype help linkpp linkps linksp list loadrt loadusr lock net newsig save setexact_for_test_suite_only setp sets show source start status stop unalias unlinkp unload unloadrt unloadusr unlock waitusr
+addf alias delf delsig getp gets ptype stype help linkpp linkps linksp list loadrt loadusr lock net newsig save setexact_for_test_suite_only setp sets show source start status stop unalias unlinkp unload unloadrt unloadusr unlock waitusr
 ----
 
-Two of the augmented comman1.ds, `list` and `gets`, require special treatment to
-avoid conflict with tcl built-in comman1.ds having the same names.  To use these
-comman1.ds, precede them with the keyword `hal`:
+Two of the augmented commands, `list` and `gets`, require special treatment to
+avoid conflict with tcl built-in commands having the same names.  To use these
+commands, precede them with the keyword `hal`:
 
 [source, bash]
 ----
@@ -80,7 +80,7 @@ comman1.ds, precede them with the keyword `hal`:
 
 == REPORTING BUGS
 Report bugs to the Machinekit forum +
-https://groups.google.com/forum/#!forum/man1.hinekit
+https://groups.google.com/forum/#!forum/machinekit
 
 == COPYRIGHT
 This is free software; see the source for copying conditions.  There is NO

--- a/docs/man/man1/haltcl.asciidoc
+++ b/docs/man/man1/haltcl.asciidoc
@@ -1,83 +1,86 @@
 ---
 ---
-:skip-front-matter:
+:skip-front-man1.ter:
 
 = HALTCL
-.de URL
-\\$2 \(laURL: \\$1 \(ra\\$3
-.if \n[.g] .mso www.tmac
 :manmanual: HAL Components
-:mansource: ../man/man1/haltcl.1.asciidoc
-:man version : 
+:mansource: ../man/man1/haltcl.asciidoc
+:man version :.
 
 
 == NAME
-haltcl -- manipulate the LinuxCNC HAL from the command line using a tcl
+**haltcl** -- man1.ipulate the LinuxCNC HAL from the comman1.d line using a tcl
 interpeter.
 
 
 
 == SYNOPSIS
-haltcl [__-i inifile__] [__filename__\]
-.PP
+**haltcl** [__-i inifile__] [__filename__]
 
 
 
 == DESCRIPTION
-**haltcl** is used to manipulate the HAL (Hardware Abstraction
-Layer) from the command line using a tcl interpreter.  **haltcl**
-can optionally read commands from a file (filename), allowing
-complex HAL configurations to be set up with a single command.
+**haltcl** is used to man1.ipulate the HAL (Hardware Abstraction
+Layer) from the comman1.d line using a tcl interpreter. +
+
+**haltcl** can optionally read comman1.ds from a file (filename), allowing
+complex HAL configurations to be set up with a single comman1.d.
 
 
 
 == OPTIONS
 
-**-i** __inifile__
+**-i** __inifile__ +
 If specified, the inifile is read and used to create tcl global variable
 arrays.  An array is created for each SECTION of the inifile with
 elements for each ITEM in the section.
-.P
+[source, bash]
+----
        For example, if the inifile contains:
-       [SECTION_A]ITEM_1 =  1
+       [SECTION_A]ITEM.=  1
        [SECTION_A]ITEM_2 =  2
-       [SECTION_B]ITEM_1 = 10
+       [SECTION_B]ITEM.=.
 
        The corresponding tcl variables are:
-       SECTION_A(ITEM_1) =  1
+       SECTION_A(ITEM. =  1
        SECTION_A(ITEM_2) =  2
-       SECTION_B(ITEM_1) = 10
+       SECTION_B(ITEM. =.
+----
 
-**-ini** __inifile__ -- declining usage, use **-i** __inifile__
+**-ini** __inifile__ -- declining usage, use **-i** __inifile__ +
 
-**filename**
-If specified, the tcl commands of **filename** are executed.  If no filename
-is specified, haltcl opens an interactive session.
+**filename** +
+If specified, the tcl comman1.ds of **filename** are executed.  If no filename
+is specified, **haltcl** opens an interactive session.
 
 
 
 == COMMANDS
-**haltcl** includes the commands of a tcl interpreter augmented with
-commands for the hal language as described for **halcmd**.  The augmented
-commands can be listed with the command:
+**haltcl** includes the comman1.ds of a tcl interpreter augmented with
+comman1.ds for the hal language as described for **halcmd**. +
+The augmented comman1.ds can be listed with the comman1.d:
 
-   haltcl: hal --commands
+[source, bash]
+----
+   haltcl: hal --comman1.ds
 
    addf alias delf delsig getp gets ptype stype help linkpp linkps linksp list loadrt loadusr lock net newsig save setexact_for_test_suite_only setp sets show source start status stop unalias unlinkp unload unloadrt unloadusr unlock waitusr
+----
 
-Two of the augmented commands, 'list' and 'gets', require special treatment to
-avoid conflict with tcl built-in commands having the same names.  To use these
-commands, precede them with the keyword 'hal':
+Two of the augmented comman1.ds, `list` and `gets`, require special treatment to
+avoid conflict with tcl built-in comman1.ds having the same names.  To use these
+comman1.ds, precede them with the keyword `hal`:
 
+[source, bash]
+----
    hal list
    hal gets
-
+----
 
 
 == REPORTING BUGS
-Report bugs to the
-.URL http://sf.net/tracker/?group_id=6744&atid=106744 "LinuxCNC bug tracker" .
-
+Report bugs to the Machinekit forum +
+https://groups.google.com/forum/#!forum/man1.hinekit
 
 == COPYRIGHT
 This is free software; see the source for copying conditions.  There is NO

--- a/docs/man/man1/halui.asciidoc
+++ b/docs/man/man1/halui.asciidoc
@@ -9,32 +9,34 @@
 
 
 == NAME
-halui -- observe HAL pins and command LinuxCNC through NML
+**halui** -- observe HAL pins and command Machinekit through NML
 
 
 == SYNOPSIS
-halui
-[**-ini <path-to-ini>**]
+**halui** [**-ini <path-to-ini>**] 
 
 
 == DESCRIPTION
 **halui** is used to build a User Interface using hardware knobs
-and switches. It exports a big number of pins, and acts accordingly 
+and switches. +
+It exports a big number of pins, and acts accordingly 
 when these change.
 
 
 == OPTIONS
 
-**-ini name**
-use the __name__ as the configuration file. Note: halui must find the 
+**-ini name** +
+use the __name__ as the configuration file. +
+Note: **halui** must find the 
 nml file specified in the ini, usually that file is in the same 
-folder as the ini, so it makes sense to run halui from that folder.
+folder as the ini, so it makes sense to run **halui** from that folder.
 
 
 == USAGE
-When run, **halui** will export a large number of pins. A user can connect
+When run, **halui** will export a large number of pins. +
+A user can connect
 those to his physical knobs & switches & leds, and when a change is noticed
-halui triggers an appropriate event.
+**halui** triggers an appropriate event.
 
 **halui** expects the signals to be debounced, so if needed (bad knob contact) connect the physical button to a HAL debounce filter first.
 
@@ -42,406 +44,408 @@ halui triggers an appropriate event.
 
 == PINS
 
-.SS abort
+=== abort
 
-halui.abort bit in 
+**halui**.abort bit in 
 pin for clearing most errors
 
-.SS tool
+=== tool
 
-halui.tool.length-offset.a float out 
+**halui**.tool.length-offset.a float out +
 current applied tool length offset for the A axis
 
-halui.tool.length-offset.b float out 
+**halui**.tool.length-offset.b float out +
 current applied tool length offset for the B axis
 
-halui.tool.length-offset.c float out 
+**halui**.tool.length-offset.c float out +
 current applied tool length offset for the C axis
 
-halui.tool.length-offset.u float out 
+**halui**.tool.length-offset.u float out +
 current applied tool length offset for the U axis
 
-halui.tool.length-offset.v float out 
+**halui**.tool.length-offset.v float out +
 current applied tool length offset for the V axis
 
-halui.tool.length-offset.w float out 
+**halui**.tool.length-offset.w float out +
 current applied tool length offset for the W axis
 
-halui.tool.length-offset.x float out 
+**halui**.tool.length-offset.x float out +
 current applied tool length offset for the X axis
 
-halui.tool.length-offset.y float out 
+**halui**.tool.length-offset.y float out +
 current applied tool length offset for the Y axis
 
-halui.tool.length-offset.z float out 
+**halui**.tool.length-offset.z float out +
 current applied tool length offset for the Z axis
 
-halui.tool.number u32 out 
+**halui**.tool.number u32 out +
 current selected tool
 
-.SS spindle
+=== spindle
 
-halui.spindle.brake-is-on bit out 
+**halui**.spindle.brake-is-on bit out +
 status pin that tells us if brake is on
 
-halui.spindle.brake-off bit in 
+**halui**.spindle.brake-off bit in +
 pin for deactivating the spindle brake
 
-halui.spindle.brake-on bit in 
+**halui**.spindle.brake-on bit in +
 pin for activating the spindle brake
 
-halui.spindle.decrease bit in 
+**halui**.spindle.decrease bit in +
 a rising edge on this pin decreases the current spindle speed by 100
 
-halui.spindle.forward bit in 
+**halui**.spindle.forward bit in +
 a rising edge on this pin makes the spindle go forward
 
-halui.spindle.increase bit in 
+**halui**.spindle.increase bit in +
 a rising edge on this pin increases the current spindle speed by 100
 
-halui.spindle.is-on bit out 
+**halui**.spindle.is-on bit out +
 status pin telling if the spindle is on
 
-halui.spindle.reverse bit in 
+**halui**.spindle.reverse bit in +
 a rising edge on this pin makes the spindle go reverse
 
-halui.spindle.runs-backward bit out 
+**halui**.spindle.runs-backward bit out 
 status pin telling if the spindle is running backward
 
-halui.spindle.runs-forward bit out 
+**halui**.spindle.runs-forward bit out +
 status pin telling if the spindle is running forward
 
-halui.spindle.start bit in 
+**halui**.spindle.start bit in +
 a rising edge on this pin starts the spindle
 
-halui.spindle.stop bit in 
+**halui**.spindle.stop bit in +
 a rising edge on this pin stops the spindle
 
-.SS spindle override
+=== spindle override
 
-halui.spindle-override.count-enable bit in  (default: **TRUE**)
+**halui**.spindle-override.count-enable bit in  (default: **TRUE**) +
 When TRUE, modify spindle override when counts changes.
 
-halui.spindle-override.counts s32 in 
+**halui**.spindle-override.counts s32 in +
 counts X scale = spindle override percentage
 
-halui.spindle-override.decrease bit in 
+**halui**.spindle-override.decrease bit in +
 pin for decreasing the SO (-=scale)
 
-halui.spindle-override.direct-value bit in 
+**halui**.spindle-override.direct-value bit in +
 pin to enable direct spindle override value input
 
-halui.spindle-override.increase bit in 
+**halui**.spindle-override.increase bit in +
 pin for increasing the SO (+=scale)
 
-halui.spindle-override.scale float in 
+**halui**.spindle-override.scale float in +
 pin for setting the scale of counts for SO
 
-halui.spindle-override.value float out 
+**halui**.spindle-override.value float out +
 current FO value
 
-.SS program
+=== program
 
-halui.program.block-delete.is-on bit out 
+**halui**.program.block-delete.is-on bit out +
 status pin telling that block delete is on
 
-halui.program.block-delete.off bit in 
+**halui**.program.block-delete.off bit in +
 pin for requesting that block delete is off
 
-halui.program.block-delete.on bit in 
+**halui**.program.block-delete.on bit in +
 pin for requesting that block delete is on
 
-halui.program.is-idle bit out 
+**halui**.program.is-idle bit out +
 status pin telling that no program is running
 
-halui.program.is-paused bit out 
+**halui**.program.is-paused bit out +
 status pin telling that a program is paused
 
-halui.program.is-running bit out 
+**halui**.program.is-running bit out +
 status pin telling that a program is running
 
-halui.program.optional-stop.is-on bit out 
+**halui**.program.optional-stop.is-on bit out +
 status pin telling that the optional stop is on
 
-halui.program.optional-stop.off bit in 
+**halui**.program.optional-stop.off bit in +
 pin requesting that the optional stop is off
 
-halui.program.optional-stop.on bit in 
+**halui**.program.optional-stop.on bit in +
 pin requesting that the optional stop is on
 
-halui.program.pause bit in 
+**halui**.program.pause bit in +
 pin for pausing a program
 
-halui.program.resume bit in 
+**halui**.program.resume bit in +
 pin for resuming a program
 
-halui.program.run bit in 
+**halui**.program.run bit in +
 pin for running a program
 
-halui.program.step bit in 
+**halui**.program.step bit in +
 pin for stepping in a program
 
-halui.program.stop bit in 
-pin for stopping a program 
-(note: this pin does the same thing as halui.abort)
+**halui**.program.stop bit in +
+pin for stopping a program +
+(note: this pin does the same thing as **halui**.abort)
 
-.SS mode
+=== mode
 
-halui.mode.auto bit in 
+**halui**.mode.auto bit in +
 pin for requesting auto mode
 
-halui.mode.is-auto bit out 
+**halui**.mode.is-auto bit out +
 pin for auto mode is on
 
-halui.mode.is-joint bit out 
+**halui**.mode.is-joint bit out +
 pin showing joint by joint jog mode is on
 
-halui.mode.is-manual bit out 
+**halui**.mode.is-manual bit out +
 pin for manual mode is on
 
-halui.mode.is-mdi bit out 
+**halui**.mode.is-mdi bit out +
 pin for mdi mode is on
 
-halui.mode.is-teleop bit out 
+**halui**.mode.is-teleop bit out +
 pin showing coordinated jog mode is on
 
-halui.mode.joint bit in 
+**halui**.mode.joint bit in +
 pin for requesting joint by joint jog mode
 
-halui.mode.manual bit in 
+**halui**.mode.manual bit in +
 pin for requesting manual mode
 
-halui.mode.mdi bit in 
+**halui**.mode.mdi bit in +
 pin for requesting mdi mode
 
-halui.mode.teleop bit in 
+**halui**.mode.teleop bit in +
 pin for requesting coordinated jog mode
 
-.SS mdi (optional)
+=== mdi (optional)
 
-halui.mdi-command-XX bit in
+**halui**.mdi-command-XX bit in +
 **halui** looks for ini variables named [HALUI]MDI_COMMAND, and
-exports a pin for each command it finds.  When the pin is driven TRUE,
+exports a pin for each command it finds.  +
+When the pin is driven TRUE,
 **halui** runs the specified MDI command.  XX is a two digit number
-starting at 00.  If no [HALUI]MDI_COMMAND variables are set in the ini
-file, no halui.mdi-command-XX pins will be exported by halui.
+starting at 00. +
+If no [HALUI]MDI_COMMAND variables are set in the ini
+file, no **halui**.mdi-command-XX pins will be exported by **halui**.
 
-.SS mist
+=== mist
 
-halui.mist.is-on bit out 
+**halui**.mist.is-on bit out +
 pin for mist is on
 
-halui.mist.off bit in 
+**halui**.mist.off bit in +
 pin for stopping mist
 
-halui.mist.on bit in 
+**halui**.mist.on bit in +
 pin for starting mist
 
-.SS max-velocity
+=== max-velocity
 
-halui.max-velocity.count-enable bit in  (default: **TRUE**)
+**halui**.max-velocity.count-enable bit in  (default: **TRUE**) +
 When TRUE, modify max velocity when counts changes.
 
-halui.max-velocity.counts s32 in 
+**halui**.max-velocity.counts s32 in +
 counts from an encoder for example to change maximum velocity
 
-halui.max-velocity.decrease bit in 
+**halui**.max-velocity.decrease bit in +
 pin for decreasing the maximum velocity (-=scale)
 
-halui.max-velocity.direct-value bit in 
+**halui**.max-velocity.direct-value bit in +
 pin for using a direct value for max velocity
 
-halui.max-velocity.increase bit in 
+**halui**.max-velocity.increase bit in +
 pin for increasing the maximum velocity (+=scale)
 
-halui.max-velocity.scale float in 
+**halui**.max-velocity.scale float in +
 pin for setting the scale on changing the maximum velocity
 
-halui.max-velocity.value float out 
+**halui**.max-velocity.value float out +
 Current value for maximum velocity
 
-.SS machine
+=== machine
 
-halui.machine.is-on bit out 
+**halui**.machine.is-on bit out +
 pin for machine is On/Off
 
-halui.machine.off bit in 
+**halui**.machine.off bit in +
 pin for setting machine Off
 
-halui.machine.on bit in 
+**halui**.machine.on bit in +
 pin for setting machine On
 
-.SS lube
+=== lube
 
-halui.lube.is-on bit out 
+**halui**.lube.is-on bit out +
 pin for lube is on
 
-halui.lube.off bit in 
+**halui**.lube.off bit in +
 pin for stopping lube
 
-halui.lube.on bit in 
+**halui**.lube.on bit in +
 pin for starting lube
 
-.SS joint
+=== joint
 
-halui.joint.N.has-fault bit out 
+**halui**.joint.N.has-fault bit out +
 status pin telling that joint N has a fault
 
-halui.joint.N.home bit in 
+**halui**.joint.N.home bit in +
 pin for homing joint N
 
-halui.joint.N.is-homed bit out 
+**halui**.joint.N.is-homed bit out +
 status pin telling that joint N is homed
 
-halui.joint.N.is-selected bit out 
+**halui**.joint.N.is-selected bit out +
 status pin that joint N is selected
 
-halui.joint.N.on-hard-max-limit bit out 
+**halui**.joint.N.on-hard-max-limit bit out +
 status pin telling that joint N is on the positive hardware limit
 
-halui.joint.N.on-hard-min-limit bit out 
+**halui**.joint.N.on-hard-min-limit bit out +
 status pin telling that joint N is on the negative hardware limit
 
-halui.joint.N.on-soft-max-limit bit out 
+**halui**.joint.N.on-soft-max-limit bit out +
 status pin telling that joint N is on the positive software limit
 
-halui.joint.N.on-soft-min-limit bit out 
+**halui**.joint.N.on-soft-min-limit bit out +
 status pin telling that joint N is on the negative software limit
 
-halui.joint.N.select bit in 
+**halui**.joint.N.select bit in +
 pin for selecting joint N
 
-halui.joint.N.unhome bit in 
+**halui**.joint.N.unhome bit in +
 pin for unhoming joint N
 
-halui.joint.selected u32 out 
+**halui**.joint.selected u32 out +
 selected joint
 
-halui.joint.selected.has-fault bit out 
+**halui**.joint.selected.has-fault bit out +
 status pin selected joint is faulted
 
-halui.joint.selected.home bit in 
+**halui**.joint.selected.home bit in +
 pin for homing the selected joint 
 
-halui.joint.selected.is-homed bit out 
+**halui**.joint.selected.is-homed bit out +
 status pin telling that the selected joint is homed
 
-halui.joint.selected.on-hard-max-limit bit out 
+**halui**.joint.selected.on-hard-max-limit bit out +
 status pin telling that the selected joint is on the positive hardware limit
 
-halui.joint.selected.on-hard-min-limit bit out 
+**halui**.joint.selected.on-hard-min-limit bit out +
 status pin telling that the selected joint is on the negative hardware limit
 
-halui.joint.selected.on-soft-max-limit bit out 
+**halui**.joint.selected.on-soft-max-limit bit out +
 status pin telling that the selected joint is on the positive software limit
 
-halui.joint.selected.on-soft-min-limit bit out 
+**halui**.joint.selected.on-soft-min-limit bit out +
 status pin telling that the selected joint is on the negative software limit
 
-halui.joint.selected.unhome bit in 
+**halui**.joint.selected.unhome bit in +
 pin for unhoming the selected joint
 
-.SS jog
+=== jog
 
-halui.jog.deadband float in 
+**halui**.jog.deadband float in +
 pin for setting jog analog deadband (jog analog inputs smaller/slower than this are ignored)
 
-halui.jog-speed float in 
+**halui**.jog-speed float in +
 pin for setting jog speed for plus/minus jogging.
 
-halui.jog.N.analog float in 
+**halui**.jog.N.analog float in +
 pin for jogging the axis N using an float value (e.g. joystick)
 
-halui.jog.N.increment float in 
+**halui**.jog.N.increment float in +
 pin for setting the jog increment for axis N when using increment-plus/minus
 
-halui.jog.N.increment-minus bit in 
+**halui**.jog.N.increment-minus bit in +
 a rising edge will will make axis N jog in the negative direction by the increment amount
 
-halui.jog.N.increment-plus bit in 
+**halui**.jog.N.increment-plus bit in +
 a rising edge will will make axis N jog in the positive direction by the increment amount
 
-halui.jog.N.minus bit in 
-pin for jogging axis N in negative direction at the halui.jog-speed velocity
+**halui**.jog.N.minus bit in +
+pin for jogging axis N in negative direction at the **halui**.jog-speed velocity
 
-halui.jog.N.plus bit in 
-pin for jogging axis N in positive direction at the halui.jog-speed velocity
+**halui**.jog.N.plus bit in +
+pin for jogging axis N in positive direction at the **halui**.jog-speed velocity
 
-halui.jog.selected.increment float in 
+**halui**.jog.selected.increment float in +
 pin for setting the jog increment for the selected axis when using increment-plus/minus
 
-halui.jog.selected.increment-minus bit in 
+**halui**.jog.selected.increment-minus bit in +
 a rising edge will will make the selected axis jog in the negative direction by the increment amount
 
-halui.jog.selected.increment-plus bit in 
+**halui**.jog.selected.increment-plus bit in +
 a rising edge will will make the selected axis jog in the positive direction by the increment amount
 
-halui.jog.selected.minus bit in 
-pin for jogging the selected axis in negative direction at the halui.jog-speed velocity
+**halui**.jog.selected.minus bit in +
+pin for jogging the selected axis in negative direction at the **halui**.jog-speed velocity
 
-halui.jog.selected.plus
-pin for jogging the selected axis  bit in in positive direction at the halui.jog-speed velocity
+**halui**.jog.selected.plus +
+pin for jogging the selected axis  bit in in positive direction at the **halui**.jog-speed velocity
 
-.SS flood
+=== flood
 
-halui.flood.is-on bit out 
+**halui**.flood.is-on bit out +
 pin for flood is on
 
-halui.flood.off bit in 
+**halui**.flood.off bit in +
 pin for stopping flood
 
-halui.flood.on bit in 
+**halui**.flood.on bit in +
 pin for starting flood
 
-.SS feed override
+=== feed override
 
-halui.feed-override.count-enable bit in  (default: **TRUE**)
+**halui**.feed-override.count-enable bit in  (default: **TRUE**) +
 When TRUE, modify feed override when counts changes.
 
-halui.feed-override.counts s32 in 
+**halui**.feed-override.counts s32 in +
 counts X scale = feed override percentage
 
-halui.feed-override.decrease bit in 
+**halui**.feed-override.decrease bit in +
 pin for decreasing the FO (-=scale)
 
-halui.feed-override.direct-value bit in 
+**halui**.feed-override.direct-value bit in +
 pin to enable direct value feed override input
 
-halui.feed-override.increase bit in 
+**halui**.feed-override.increase bit in +
 pin for increasing the FO (+=scale)
 
-halui.feed-override.scale float in 
+**halui**.feed-override.scale float in +
 pin for setting the scale on changing the FO
 
-halui.feed-override.value float out 
+**halui**.feed-override.value float out +
 current Feed Override value
 
-.SS estop
+=== estop
 
-halui.estop.activate bit in 
-pin for setting Estop (LinuxCNC internal) On
+**halui**.estop.activate bit in +
+pin for setting Estop (Machinekit internal) On
 
-halui.estop.is-activated bit out 
-pin for displaying Estop state (LinuxCNC internal) On/Off
+**halui**.estop.is-activated bit out +
+pin for displaying Estop state (Machinekit internal) On/Off
 
-halui.estop.reset bit in 
-pin for resetting Estop (LinuxCNC internal) Off
+**halui**.estop.reset bit in +
+pin for resetting Estop (Machinekit internal) Off
 
-.SS axis
+=== axis
 
-halui.axis.N.pos-commanded float out  float out 
+**halui**.axis.N.pos-commanded float out  float out +
 Commanded axis position in machine coordinates
 
-halui.axis.N.pos-feedback float out  float out 
+**halui**.axis.N.pos-feedback float out  float out +
 Feedback axis position in machine coordinates
 
-halui.axis.N.pos-relative float out  float out 
+**halui**.axis.N.pos-relative float out  float out +
 Commanded axis position in relative coordinates
 
-.SS home
+=== home
 
-halui.home-all bit in 
-pin for requesting home-all 
+**halui**.home-all bit in +
+pin for requesting home-all +
 (only available when a valid homing sequence is specified)
 
 
@@ -460,14 +464,14 @@ none known at this time.
 
 == AUTHOR
 Written by Alex Joni, as part of the LinuxCNC project. Updated by John
-Thornton
+Thornton.  Now part of the Machinekit project.
 
 
 == REPORTING BUGS
-Report bugs to alex_joni AT users DOT sourceforge DOT net
-
+Report bugs to the Machinekit forum +
+https://groups.google.com/forum/#!forum/machinekit
 
 == COPYRIGHT
-Copyright \(co 2006 Alex Joni.
+Copyright (c) 2006 Alex Joni. +
 This is free software; see the source for copying conditions.  There is NO
 warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

--- a/docs/man/man1/halui.asciidoc
+++ b/docs/man/man1/halui.asciidoc
@@ -4,7 +4,7 @@
 
 = HALUI
 :manmanual: HAL Components
-:mansource: ../man/man1/halui.1.asciidoc
+:mansource: ../man/man1/halui.asciidoc
 :man version : 
 
 

--- a/docs/man/man1/iocontrol.asciidoc
+++ b/docs/man/man1/iocontrol.asciidoc
@@ -4,7 +4,7 @@
 
 = IOCONTROL
 :manmanual: HAL Components
-:mansource: ../man/man1/iocontrol.1.asciidoc
+:mansource: ../man/man1/iocontrol.asciidoc
 :man version : 
 
 

--- a/docs/man/man1/linuxcnc.asciidoc
+++ b/docs/man/man1/linuxcnc.asciidoc
@@ -4,7 +4,7 @@
 
 = LinuxCNC
 :manmanual: HAL Components
-:mansource: ../man/man1/linuxcnc.1.asciidoc
+:mansource: ../man/man1/linuxcnc.asciidoc
 :man version : 
 
 

--- a/docs/man/man1/linuxcncrsh.asciidoc
+++ b/docs/man/man1/linuxcncrsh.asciidoc
@@ -4,7 +4,7 @@
 
 = linuxcncrsh
 :manmanual: HAL Components
-:mansource: ../man/man1/linuxcncrsh.1.asciidoc
+:mansource: ../man/man1/linuxcncrsh.asciidoc
 :man version : 
 
 

--- a/docs/man/man1/pyvcp.asciidoc
+++ b/docs/man/man1/pyvcp.asciidoc
@@ -4,7 +4,7 @@
 
 = PYVCP
 :manmanual: HAL Components
-:mansource: ../man/man1/pyvcp.1.asciidoc
+:mansource: ../man/man1/pyvcp.asciidoc
 :man version : 
 
 

--- a/docs/man/man1/shuttlexpress.asciidoc
+++ b/docs/man/man1/shuttlexpress.asciidoc
@@ -4,7 +4,7 @@
 
 = SHUTTLEXPRESS
 :manmanual: HAL Components
-:mansource: ../man/man1/shuttlexpress.1.asciidoc
+:mansource: ../man/man1/shuttlexpress.asciidoc
 :man version : 
 
 

--- a/docs/man/man1/vfdb_vfd.asciidoc
+++ b/docs/man/man1/vfdb_vfd.asciidoc
@@ -4,7 +4,7 @@
 
 = vfdb_vfd
 :manmanual: HAL Components
-:mansource: ../man/man1/vfdb_vfd.1.asciidoc
+:mansource: ../man/man1/vfdb_vfd.asciidoc
 :man version : 
 
 

--- a/docs/man/man1/vfs11_vfd.asciidoc
+++ b/docs/man/man1/vfs11_vfd.asciidoc
@@ -4,7 +4,7 @@
 
 = vfs11_vfd
 :manmanual: HAL Components
-:mansource: ../man/man1/vfs11_vfd.1.asciidoc
+:mansource: ../man/man1/vfs11_vfd.asciidoc
 :man version : 
 
 

--- a/docs/man/man9/classicladder.asciidoc
+++ b/docs/man/man9/classicladder.asciidoc
@@ -2,9 +2,9 @@
 ---
 :skip-front-matter:
 
-= CLASSICLADDER(9)
+= CLASSICLADDER
 :manmanual: HAL Components
-:mansource: ../man/man9/classicladder.9.asciidoc
+:mansource: ../man/man9/classicladder.asciidoc
 :man version : 
 
 == NAME

--- a/docs/man/man9/counter.asciidoc
+++ b/docs/man/man9/counter.asciidoc
@@ -2,9 +2,9 @@
 ---
 :skip-front-matter:
 
-= COUNTER(9)
+= COUNTER
 :manmanual: HAL Components
-:mansource: ../man/man9/counter.9.asciidoc
+:mansource: ../man/man9/counter.asciidoc
 :man version : 
 
 == NAME
@@ -97,4 +97,4 @@ in the output pins at the next call to **capture-position**.
 ====
 
 == SEE ALSO
-**encoder(9)** in the Machinekit documentation.
+**encoder** in the Machinekit documentation.

--- a/docs/man/man9/delayline.asciidoc
+++ b/docs/man/man9/delayline.asciidoc
@@ -2,9 +2,9 @@
 ---
 :skip-front-matter:
 
-= DELAYLINE(9)
+= DELAYLINE
 :manmanual: HAL Components
-:mansource: ../man/man9/delayline.9.asciidoc
+:mansource: ../man/man9/delayline.asciidoc
 :man version : 
 
 == NAME

--- a/docs/man/man9/encoder.asciidoc
+++ b/docs/man/man9/encoder.asciidoc
@@ -2,9 +2,9 @@
 ---
 :skip-front-matter:
 
-= ENCODER(9)
+= ENCODER
 :manmanual: HAL Components
-:mansource: ../man/man9/encoder.9.asciidoc
+:mansource: ../man/man9/encoder.asciidoc
 :man version : 
 
 == NAME

--- a/docs/man/man9/encoder_ratio.asciidoc
+++ b/docs/man/man9/encoder_ratio.asciidoc
@@ -2,9 +2,9 @@
 ---
 :skip-front-matter:
 
-= ENCODER_RATIO(9)
+= ENCODER_RATIO
 :manmanual: HAL Components
-:mansource: ../man/man9/encoder_ratio.9.asciidoc
+:mansource: ../man/man9/encoder_ratio.asciidoc
 :man version : 
 
 == NAME
@@ -110,4 +110,4 @@ The number of "teeth" on the master and slave gears.
 ====
 
 == SEE ALSO
-**encoder(9)**
+**encoder**

--- a/docs/man/man9/gantrykins.asciidoc
+++ b/docs/man/man9/gantrykins.asciidoc
@@ -2,9 +2,9 @@
 ---
 :skip-front-matter:
 
-= GANTRYKINS(9)
+= GANTRYKINS
 :manmanual: HAL Components
-:mansource: ../man/man9/gantrykins.9.asciidoc
+:mansource: ../man/man9/gantrykins.asciidoc
 :man version : 
 
 == NAME

--- a/docs/man/man9/gladevcp.asciidoc
+++ b/docs/man/man9/gladevcp.asciidoc
@@ -2,9 +2,9 @@
 ---
 :skip-front-matter:
 
-= gladevcp(9)
+= gladevcp
 :manmanual: HAL Components
-:mansource: ../man/man9/gladevcp.9.asciidoc
+:mansource: ../man/man9/gladevcp.asciidoc
 :man version : 
 
 == NAME

--- a/docs/man/man9/hal_pru_generic.asciidoc
+++ b/docs/man/man9/hal_pru_generic.asciidoc
@@ -2,9 +2,9 @@
 ---
 :skip-front-matter:
 
-= HAL_PRU_GENERIC(9)
+= HAL_PRU_GENERIC
 :manmanual: HAL Components
-:mansource: ../man/man9/hal_pru_generic.9.asciidoc
+:mansource: ../man/man9/hal_pru_generic.asciidoc
 :man version : 
 
 == NAME

--- a/docs/man/man9/hm2_7i43.asciidoc
+++ b/docs/man/man9/hm2_7i43.asciidoc
@@ -2,9 +2,9 @@
 ---
 :skip-front-matter:
 
-= HM2_7I43(9)
+= HM2_7I43
 :manmanual: HAL Components
-:mansource: ../man/man9/hm2_7i43.9.asciidoc
+:mansource: ../man/man9/hm2_7i43.asciidoc
 :man version : 
 
 == NAME
@@ -110,7 +110,7 @@ Access to the EPP bus is not threadsafe: only one realtime thread may
 access the EPP bus.
 
 == SEE ALSO
-hostmot2(9)
+hostmot2
 
 == LICENSE
 GPL

--- a/docs/man/man9/hm2_pci.asciidoc
+++ b/docs/man/man9/hm2_pci.asciidoc
@@ -2,9 +2,9 @@
 ---
 :skip-front-matter:
 
-= HM2_PCI(9)
+= HM2_PCI
 :manmanual: HAL Components
-:mansource: ../man/man9/hm2_pci.9.asciidoc
+:mansource: ../man/man9/hm2_pci.asciidoc
 :man version : 
 
 == NAME
@@ -33,7 +33,7 @@ in the __config modparam__ section.
 
 
 == SEE ALSO
-hostmot2(9)
+hostmot2
 
 
 == LICENSE

--- a/docs/man/man9/hostmot2.asciidoc
+++ b/docs/man/man9/hostmot2.asciidoc
@@ -2,9 +2,9 @@
 ---
 :skip-front-matter:
 
-= HOSTMOT2(9)
+= HOSTMOT2
 :manmanual: HAL Components
-:mansource: ../man/man9/hostmot2.9.asciidoc
+:mansource: ../man/man9/hostmot2.asciidoc
 :man version : 
 
 == NAME
@@ -1588,8 +1588,8 @@ it is better to use the synchronous hm2dpll triggering function.
 ==== 
 
 == SEE ALSO
-* hm2_7i43(9)
-* hm2_pci(9)
+* hm2_7i43
+* hm2_pci
 * Mesa's documentation for the Anything I/O boards, at <http://www.mesanet.com>
 
 == LICENSE

--- a/docs/man/man9/kins.asciidoc
+++ b/docs/man/man9/kins.asciidoc
@@ -2,9 +2,9 @@
 ---
 :skip-front-matter:
 
-= KINS(9)
+= KINS
 :manmanual: HAL Components
-:mansource: ../man/man9/kins.9.asciidoc
+:mansource: ../man/man9/kins.asciidoc
 :man version : 
 
 

--- a/docs/man/man9/lcd.asciidoc
+++ b/docs/man/man9/lcd.asciidoc
@@ -2,9 +2,9 @@
 ---
 :skip-front-matter:
 
-= LCD(9)
+= LCD
 :manmanual: HAL Components
-:mansource: ../man/man9/lcd.9.asciidoc
+:mansource: ../man/man9/lcd.asciidoc
 :man version : 
 
 == NAME

--- a/docs/man/man9/lineardeltakins.asciidoc
+++ b/docs/man/man9/lineardeltakins.asciidoc
@@ -2,9 +2,9 @@
 ---
 :skip-front-matter:
 
-= LINEARDELTAKINS(9)
+= LINEARDELTAKINS
 :manmanual: HAL Components
-:mansource: ../man/man9/lineardeltakins.9.asciidoc
+:mansource: ../man/man9/lineardeltakins.asciidoc
 :man version : 
 
 == NAME

--- a/docs/man/man9/matrix_kb.asciidoc
+++ b/docs/man/man9/matrix_kb.asciidoc
@@ -2,9 +2,9 @@
 ---
 :skip-front-matter:
 
-= MATRIX_KB(9)
+= MATRIX_KB
 :manmanual: HAL Components
-:mansource: ../man/man9/matrix_kb.9.asciidoc
+:mansource: ../man/man9/matrix_kb.asciidoc
 :man version : 
 
 == NAME

--- a/docs/man/man9/motion.asciidoc
+++ b/docs/man/man9/motion.asciidoc
@@ -2,9 +2,9 @@
 ---
 :skip-front-matter:
 
-= MOTION(9)
+= MOTION
 :manmanual: HAL Components
-:mansource: ../man/man9/motion.9.asciidoc
+:mansource: ../man/man9/motion.asciidoc
 :man version : 
 
 
@@ -440,4 +440,4 @@ This manual page is horribly incomplete.
 
 
 == SEE ALSO
-iocontrol(1)
+iocontrol

--- a/docs/man/man9/mux_generic.asciidoc
+++ b/docs/man/man9/mux_generic.asciidoc
@@ -2,11 +2,9 @@
 ---
 :skip-front-matter:
 
-= MUX_GENERIC(9)
-\# Author Andy Pugh
-\# Issued under the terms of the GPL v2 License or any later version
+= MUX_GENERIC
 :manmanual: HAL Components
-:mansource: ../man/man9/mux_generic.9.asciidoc
+:mansource: ../man/man9/mux_generic.asciidoc
 :man version : 
 
 

--- a/docs/man/man9/new_delayline.asciidoc
+++ b/docs/man/man9/new_delayline.asciidoc
@@ -2,9 +2,9 @@
 ---
 :skip-front-matter:
 
-= DELAYLINE(9)
+= DELAYLINE
 :manmanual: HAL Components
-:mansource: ../man/man9/delayline.9.asciidoc
+:mansource: ../man/man9/delayline.asciidoc
 :man version : 
 
 

--- a/docs/man/man9/opto_ac5.asciidoc
+++ b/docs/man/man9/opto_ac5.asciidoc
@@ -2,9 +2,9 @@
 ---
 :skip-front-matter:
 
-= OPTO_AC5(9)
+= OPTO_AC5
 :manmanual: HAL Components
-:mansource: ../man/man9/opto_ac5.9.asciidoc
+:mansource: ../man/man9/opto_ac5.asciidoc
 :man version : 
 
 

--- a/docs/man/man9/pid.asciidoc
+++ b/docs/man/man9/pid.asciidoc
@@ -2,9 +2,9 @@
 ---
 :skip-front-matter:
 
-= PID(9)
+= PID
 :manmanual: HAL Components
-:mansource: ../man/man9/pid.9.asciidoc
+:mansource: ../man/man9/pid.asciidoc
 :man version : 
 
 

--- a/docs/man/man9/pwmgen.asciidoc
+++ b/docs/man/man9/pwmgen.asciidoc
@@ -2,9 +2,9 @@
 ---
 :skip-front-matter:
 
-= PWMGEN(9)
+= PWMGEN
 :manmanual: HAL Components
-:mansource: ../man/man9/pwmgen.9.asciidoc
+:mansource: ../man/man9/pwmgen.asciidoc
 :man version : 
 
 

--- a/docs/man/man9/sampler.asciidoc
+++ b/docs/man/man9/sampler.asciidoc
@@ -2,9 +2,9 @@
 ---
 :skip-front-matter:
 
-= SAMPLER(9)
+= SAMPLER
 :manmanual: HAL Components
-:mansource: ../man/man9/sampler.9.asciidoc
+:mansource: ../man/man9/sampler.asciidoc
 :man version : 
 
 
@@ -128,9 +128,9 @@ option. (see
 
 
 == SEE ALSO
- halsampler (1)
- streamer (9)
- halstreamer (1)
+ halsampler
+ streamer
+ halstreamer
 
 
 

--- a/docs/man/man9/setsserial.asciidoc
+++ b/docs/man/man9/setsserial.asciidoc
@@ -117,3 +117,7 @@ feedback terminal after the loadrt hm2_pci step of the sequence.
 == LICENSE
 
 GPL
+
+
+== AUTHOR
+Andy Pugh

--- a/docs/man/man9/setsserial.asciidoc
+++ b/docs/man/man9/setsserial.asciidoc
@@ -2,11 +2,9 @@
 ---
 :skip-front-matter:
 
-= SETSERIAL(9)
-\# Author Andy Pugh
-\# Issued under the terms of the GPL v2 License or any later version
+= SETSERIAL
 :manmanual: HAL Components
-:mansource: ../man/man9/setsserial.9.asciidoc
+:mansource: ../man/man9/setsserial.asciidoc
 :man version : 
 
 

--- a/docs/man/man9/siggen.asciidoc
+++ b/docs/man/man9/siggen.asciidoc
@@ -2,9 +2,9 @@
 ---
 :skip-front-matter:
 
-= SIGGEN(9)
+= SIGGEN
 :manmanual: HAL Components
-:mansource: ../man/man9/siggen.9.asciidoc
+:mansource: ../man/man9/siggen.asciidoc
 :man version : 
 
 

--- a/docs/man/man9/sim_encoder.asciidoc
+++ b/docs/man/man9/sim_encoder.asciidoc
@@ -2,9 +2,9 @@
 ---
 :skip-front-matter:
 
-= SIM_ENCODER(9)
+= SIM_ENCODER
 :manmanual: HAL Components
-:mansource: ../man/man9/sim_encoder.9.asciidoc
+:mansource: ../man/man9/sim_encoder.asciidoc
 :man version : 
 
 

--- a/docs/man/man9/sserial.asciidoc
+++ b/docs/man/man9/sserial.asciidoc
@@ -557,4 +557,9 @@ Parameters:
 
 TODO: Add 7i77, 7i66, 7i72, 7i83, 7i84, 7i87. 
 
+== LICENSE
+GPL
 
+
+== AUTHOR
+Andy Pugh

--- a/docs/man/man9/sserial.asciidoc
+++ b/docs/man/man9/sserial.asciidoc
@@ -2,11 +2,9 @@
 ---
 :skip-front-matter:
 
-= SSERIAL(9)
-\# Author Andy Pugh
-\# Issued under the terms of the GPL v2 License or any later version
+= SSERIAL
 :manmanual: HAL Components
-:mansource: ../man/man9/sserial.9.asciidoc
+:mansource: ../man/man9/sserial.asciidoc
 :man version : 
 
 

--- a/docs/man/man9/stepgen.asciidoc
+++ b/docs/man/man9/stepgen.asciidoc
@@ -2,9 +2,9 @@
 ---
 :skip-front-matter:
 
-= STEPGEN(9)
+= STEPGEN
 :manmanual: HAL Components
-:mansource: ../man/man9/stepgen.9.asciidoc
+:mansource: ../man/man9/stepgen.asciidoc
 :man version : 
 
 

--- a/docs/man/man9/streamer.asciidoc
+++ b/docs/man/man9/streamer.asciidoc
@@ -2,9 +2,9 @@
 ---
 :skip-front-matter:
 
-= STREAMER(9)
+= STREAMER
 :manmanual: HAL Components
-:mansource: ../man/man9/streamer.9.asciidoc
+:mansource: ../man/man9/streamer.asciidoc
 :man version : 
 
 
@@ -110,10 +110,9 @@ command.
 
 
 == SEE ALSO
- halstreamer (1)
- sampler (9)
- halsampler (1)
-
+ halstreamer
+ sampler
+ halsampler
 
 
 == HISTORY

--- a/docs/man/man9/supply.asciidoc
+++ b/docs/man/man9/supply.asciidoc
@@ -2,9 +2,9 @@
 ---
 :skip-front-matter:
 
-= SUPPLY(9)
+= SUPPLY
 :manmanual: HAL Components
-:mansource: ../man/man9/supply.9.asciidoc
+:mansource: ../man/man9/supply.asciidoc
 :man version : 
 
 

--- a/docs/man/man9/threads.asciidoc
+++ b/docs/man/man9/threads.asciidoc
@@ -2,9 +2,9 @@
 ---
 :skip-front-matter:
 
-= THREADS(9)
+= THREADS
 :manmanual: HAL Components
-:mansource: ../man/man9/threads.9.asciidoc
+:mansource: ../man/man9/threads.asciidoc
 :man version : 
 
 

--- a/docs/man/man9/watchdog.asciidoc
+++ b/docs/man/man9/watchdog.asciidoc
@@ -2,9 +2,9 @@
 ---
 :skip-front-matter:
 
-= WATCHDOG(9)
+= WATCHDOG
 :manmanual: HAL Components
-:mansource: ../man/man9/watchdog.9.asciidoc
+:mansource: ../man/man9/watchdog.asciidoc
 :man version : 
 
 


### PR DESCRIPTION
De-troff haltcl.asciidoc and correct /man/man1 filenames in header mansource:

Correct /man/man9 filenames in header mansource: & remove (9) refs.

Further de-troffing and cleaning man/man1 haltcl and halui