### PR TITLE
should clone user's fork, not main repository

### DIFF
--- a/docs/developing/machinekit-developing.asciidoc
+++ b/docs/developing/machinekit-developing.asciidoc
@@ -42,6 +42,17 @@ sudo apt-get install -t wheezy-backports cython
 ----
 
 == [[get-source-and-build]]Get and build the source
+IMPORTANT If you wish to contribute changes back to the project, do NOT
+clone the main project repository (3rd line below).  Instead, read
+this page: http://www.machinekit.io/community/contributing/
+Create a Github account, fork the main project repository, clone your
+fork, and synch your fork to the main project repository.
+The instructions below should be revised to show that process in detail,
+but I don't have time right now.  Additional details are on these
+github pages:
+https://help.github.com/articles/fork-a-repo/
+https://help.github.com/articles/syncing-a-fork/
+
 
 [source,bash]
 ----


### PR DESCRIPTION
The existing instructions are fine for getting the source and building, but do not comply with the "fork and pull request" method for contributing to the project as described at http://www.machinekit.io/community/contributing/ .  The instructions should tell you to open a github account, fork the main repository, and clone your fork.  That will allow you to push changes to your fork and generate a pull request.  If you follow the instructions on this page you will have to start over before you can contribute.