### PR TITLE
update halcmd man page

### DIFF
--- a/docs/hal/tools.asciidoc
+++ b/docs/hal/tools.asciidoc
@@ -12,15 +12,11 @@
 == Halcmd[[sec:Halcmd]]
 
 Halcmd is a command line tool for manipulating the HAL. There is a
-rather complete man page for halcmd, which will be installed if you
-have installed Machinekit from either source or a package. If you have
-compiled Machinekit for “run-in-place”, the man page is not installed, but it
-is accessible. From the main Machinekit directory, do:
-
-[source]
-----
-man -M docs/man halcmd
-----
+rather complete man page for halcmd and the HAL language, which is
+available on the Machinekit website.  Man pages are not installed 
+as part of the main Machinekit packages, however an optional package
+"machinekit-manual-pages" is available.  Note that the Machinekit 
+man pages should be accessed using "mank foo", not "man foo".
 
 The <<cha:HAL-tutorial,HAL Tutorial>> has a number of examples of halcmd
 usage, and is a good tutorial for halcmd.

--- a/docs/man/man1/halcmd.asciidoc
+++ b/docs/man/man1/halcmd.asciidoc
@@ -344,6 +344,22 @@ Fails if __name__ does not exist as a pin or parameter. +
 If a pin and a parameter both exist with the given name, the
 parameter is acted on.
 
+=== newthread
+**newthread** __threadname__ [__options__] __period__
+
+Creates a new HAL thread named __threadname__ which runs every
+__period__ nanoseconds.  Options are:
+
+fp	(deprecated) thread supports floating point
+
+nofp	(deprecated) (default) thread does not support floating point
+
+cpu=N	run thread on CPU #N
+
+nowait	(experimental) ignores period, thread free-runs and must be synchronized externally
+
+posix	(experimental) non-realtime posix thread.  Can make Linux system calls, but has no timing guarantees
+
 === addf
 **addf** __functname__ __threadname__
 (__add__ __f__unction)  


### PR DESCRIPTION
Added documentation for the "newthread" command to halcmd man page.  Also changes some outdated notes about manpages, and documented the use of "mank" instead of "man" to read them.