### PR TITLE
Amend man-stubs script

### DIFF
--- a/scripts/man-stubs.sh
+++ b/scripts/man-stubs.sh
@@ -1,29 +1,30 @@
 #!/bin/sh
+# $1 = directory to output to
 
-mkdir -p docs/man/man1/links
+mkdir -p $1/man1
 for i in docs/man/man1/*.asciidoc ; do
     compname=$(basename -s .asciidoc "$i") ;
     if [ $compname != "index" ] ; then        
-	ln -s -f /usr/share/man/man1/machinekit.1 docs/man/man1/links/$compname.1	
+	ln -s -f /usr/share/man/man1/machinekit.1 $1/man1/$compname.1	
     fi
 done
 
-mkdir -p docs/man/man3/links
+mkdir -p $1/man3
 for i in docs/man/man3/*.asciidoc ; do
     compname=$(basename -s .asciidoc "$i") ;
     if [ $compname != "index" ] ; then        
-	ln -s -f /usr/share/man/man1/machinekit.1 docs/man/man3/links/$compname.3
+	ln -s -f /usr/share/man/man1/machinekit.1 $1/man3/$compname.3
     fi
 done
 
-mkdir -p docs/man/man9/links
+mkdir -p $1/man9
 for i in docs/man/man9/*.asciidoc ; do
     compname=$(basename -s .asciidoc "$i") ;
     if [ $compname != "index" ] ; then        
-	ln -s -f /usr/share/man/man1/machinekit.1 docs/man/man9/links/$compname.9
+	ln -s -f /usr/share/man/man1/machinekit.1 $1/man9/$compname.9
     fi
 done
 
-echo "Links created"
+echo "Links created in $1"
 
 


### PR DESCRIPTION
fpm used in jenkins to create packages, does not seem to work with
file globs, only individual files or complete dirs

Need man-stubs to be able to be scripted with an arg,
to create a dir in the Jenkins workspace to hold the links,
so they can be passed to fpm as directory addresses

Signed-off-by: Mick <arceye@mgware.co.uk>