### PR TITLE
threads component is deprecated

### DIFF
--- a/docs/man/man9/threads.asciidoc
+++ b/docs/man/man9/threads.asciidoc
@@ -7,8 +7,7 @@
 :mansource: ../man/man9/threads.asciidoc
 :man version : 
 
-
-
+== DEPRECATED - use "newthread" command instead
 
 == NAME
 threads -- creates hard realtime HAL threads


### PR DESCRIPTION
PR 1026 in machinekit replaces the threads component with "newthread" command.
This PR updates machinekit-docs to match.