### PR TITLE
Tidy and format /man9 components

### DIFF
--- a/docs/man/man9/classicladder.asciidoc
+++ b/docs/man/man9/classicladder.asciidoc
@@ -11,7 +11,8 @@
 classicladder - realtime software plc based on ladder logic
 
 == SYNOPSIS
-**loadrt classicladder_rt  [numRungs=**__N__**] [numBits=**__N__**] [numWords=**__N__**] [numTimers=**__N__**] [numMonostables=**__N__**] [numCounters=**__N__**] [numPhysInputs=**__N__**] [numPhysOutputs=**__N__**] [numArithmExpr=**__N__**] [numSections=**__N__**] [numSymbols=**__N__**] [numS32in=**__N__**] [numS32out=**__N__**]**
+**loadrt classicladder_rt** 
+ __[numRungs=N] [numBits=N] [numWords=N] [numTimers=N] [numMonostables=N] [numCounters=N] [numPhysInputs=N] [numPhysOutputs=N] [numArithmExpr=N] [numSections=N] [numSymbols=N] [numS32in=N] [numS32out=N]__
 
 == DESCRIPTION
 These pins and parameters are created by the realtime **classicladder_rt** module. Each period (minimum 1000000 ns), classicladder reads the inputs, evaluates the ladder logic defined in the GUI, and then writes the outputs.

--- a/docs/man/man9/delayline.asciidoc
+++ b/docs/man/man9/delayline.asciidoc
@@ -9,13 +9,13 @@
 
 == NAME
 
-delayline - buffer for delaying pins
+**delayline** - buffer for delaying pins
 
 == SYNOPSIS
-loadrt delayline names=foo,bar max_delay=500,2500 samples=ffb,ffbsu
+**loadrt delayline** __names=foo,bar max_delay=500,2500 samples=ffb,ffbsu__
 
 == DELAYLINE
-The delayline will sample the value of an input pin, and put the sample
+The **delayline** will sample the value of an input pin, and put the sample
 in the output pin after a certain amount of periods.
 
 With this component it is possible to attach with another component to
@@ -38,16 +38,22 @@ The pins of the component are created in a HAL section of the ring buffer
 thus making the values of the pins available thru attaching to the ring.
 
 == THREADS
-delayline.**sample** use like: __addf delayline.sample realtime-thread__
-
+**delayline.sample** use like: 
+[source,bash]
+----
+addf delayline.sample realtime-thread
+----
 [indent=4]
 ====
 To be called by a thread to be executed. This function puts the sample
 from a pin into the buffer.
 ====
 
-delayline.**output** use like: __addf delayline.output realtime-thread__
-
+**delayline.output** use like: 
+[source,bash]
+----
+addf delayline.output realtime-thread
+----
 [indent=4]
 ====
 To be called by a thread to be executed. This function reads the
@@ -59,15 +65,15 @@ delay) will be dropped.
 
 == PINS
 
-delayline.**enable** bit in
+**delayline.enable** bit in
 
 [indent=4]
 ====
-Enables the delayline, when not enabled, the input sample is set
+Enables the **delayline**, when not enabled, the input sample is set
 directly to the output pin.
 ====
 
-delayline.**abort** bit in
+**delayline.abort** bit in
 
 [indent=4]
 ====
@@ -75,14 +81,14 @@ This flushes the buffer. The user is responsible for whether this
 pin is attached.
 ====
 
-delayline.**delay** float in
+**delayline.delay** float in
 
 [indent=4]
 ====
 The delay in thread periods.
 ====
 
-delayline.__{type}__**-in**__{N}__ the input sample pin
+**delayline**.__{type}__**-in**__{N}__ the input sample pin
 
 [indent=4]
 ====
@@ -94,10 +100,10 @@ line, so flt-in2 is the pin that is generated after bit-in1.
 The input sample pin is matched by output sample pin.
 
 **delayline.flt-in0** is the source of the delayed
-delayline.flt-out0 pin
+**delayline**.flt-out0 pin
 ====
 
-delayline.__{type}__**-out**__{N}__ the input sample pin
+**delayline**.__{type}__**-out**__{N}__ the input sample pin
 
 [indent=4]
 ====
@@ -108,25 +114,25 @@ line, so flt-out2 is the pin that is generated after bit-out1.
 
 The output sample pin is matched by input sample pin
 
-**delayline.flt-out0 **is the delay of the delayline.flt-out0
+**delayline.flt-out0 **is the delay of the **delayline**.flt-out0
 input sample
 ====
 
-delayline.**write-fail** u32 out
+**delayline.write-fail** u32 out
 
 [indent=4]
 ====
 counter of failed writes
 ====
 
-delayline.**read-fail** u32 out
+**delayline.read-fail** u32 out
 
 [indent=4]
 ====
 counter of failed reads
 ====
 
-delayline.**too-old** u32 out
+**delayline.too-old** u32 out
 
 [indent=4]
 ====

--- a/docs/man/man9/encoder.asciidoc
+++ b/docs/man/man9/encoder.asciidoc
@@ -8,10 +8,10 @@
 :man version : 
 
 == NAME
-encoder - software counting of quadrature encoder signals
+**encoder** - software counting of quadrature encoder signals
 
 == SYNOPSIS
-**loadrt encoder [num_chan=**__num__** | names=**__name1__**[,**__name2...__**]]**
+**loadrt encoder** __[num_chan=**num** | names=**name1**[,**name2...**]]__
 
 == DESCRIPTION
 **encoder** is used to measure position by counting the pulses

--- a/docs/man/man9/encoder_ratio.asciidoc
+++ b/docs/man/man9/encoder_ratio.asciidoc
@@ -8,11 +8,10 @@
 :man version : 
 
 == NAME
-encoder_ratio - an electronic gear to synchronize two axes
+**encoder_ratio** - an electronic gear to synchronize two axes
 
 == SYNOPSIS
-**loadrt encoder_ratio [num_chan=**__num__** | names=**__name1__**[,**__name2...__**]]
-**
+**loadrt encoder_ratio** __[num_chan=**num** | names=**name1**[,**name2...**]]__
 
 == DESCRIPTION
 **encoder_ratio** can be used to synchronize two axes (like an "electronic

--- a/docs/man/man9/gantrykins.asciidoc
+++ b/docs/man/man9/gantrykins.asciidoc
@@ -8,12 +8,12 @@
 :man version : 
 
 == NAME
-gantrykins - A kinematics module that maps one axis to multiple joints
+**gantrykins** - A kinematics module that maps one axis to multiple joints
 
 == SYNOPSIS
-**loadrt gantrykins coordinates=**__axisletters__
+**loadrt gantrykins** __coordinates=[X[Y[Z[A[B[C...]]]]]]__
 
-**Specifying gantry joint mapping via loadrt**
+=== Specifying gantry joint mapping via loadrt
 
 [indent=4]
 ====
@@ -26,11 +26,11 @@ the default mapping is **coordinates=XYZABC**. Coordinate
 letters may be specified in uppercase or lowercase.
 ====
 
-**A note about joints and axes**
+=== A note about joints and axes
 
 [indent=4]
 ====
-LinuxCNC makes a distinction between joints and axes: a joint
+Machinekit makes a distinction between joints and axes: a joint
 is something controlled by a motor, and an axis is a coordinate
 you can move via G-code. You can also jog joints or jog axes.
 
@@ -45,7 +45,7 @@ Jogging of a gantry must happen in world mode (aka Teleop mode).
 If you jog a gantry in joint mode (Free mode), you will move
 just one of the joints, and the gantry will rack.  In contrast,
 if you jog a gantry in world mode (Teleop mode), it's the axis
-that jogs: linuxcnc will coordinate the motion of the two joints
+that jogs: machinekit will coordinate the motion of the two joints
 that make up the axis, both joints will move together, and the
 gantry will stay square.
 

--- a/docs/man/man9/gladevcp.asciidoc
+++ b/docs/man/man9/gladevcp.asciidoc
@@ -8,23 +8,27 @@
 :man version : 
 
 == NAME
-gladevcp - displays Virtual control Panels built with GTK / GLADE 
+**gladevcp** - displays Virtual control Panels built with GTK / GLADE 
 
 == SYNOPSIS
-**loadusr gladevcp  [-c componentname0x**__N__**] [-g WxH+Xoffset+Yoffset0x**__N__**] [-H halcmdfile] [-x windowid] gladefile.glade
-**
+**loadusr gladevcp** __[-c componentname0x**N**] [-g WxH+Xoffset+Yoffset0x**N**] [-H halcmdfile] [-x windowid] gladefile.glade__
 
 == DESCRIPTION
-gladevcp parses a glade file and displays the widgets in a window.
-Then calls gladevcp_makepins which again parses the gladefile looking for specific HAL widgets
+**gladevcp** parses a glade file and displays the widgets in a window.
+Then calls **gladevcp**_makepins which again parses the gladefile looking for specific HAL widgets
 then makes HAL pins and sets up updating for them. 
-The HAL component name defaults to the basename of the glade file.
-The -x option directs gladevcp to reparent itself under this X window id instead of creating its own toplevel window.
-The -H option passes an input file for halcmd to be run after the gladevcp component is initialized. This is used in Axis when 
-running gladevcp under a tab with the EMBED_TAB_NAME/EMBED_TAB_COMMAND ini file feature.
 
-gladevcp supports gtkbuilder or libglade files though some widgets are not fully supported in gtkbuilder yet.
+The HAL component name defaults to the basename of the glade file.
+
+The -x option directs **gladevcp** to reparent itself under this X window id instead of creating its own toplevel window.
+
+The -H option passes an input file for halcmd to be run after the **gladevcp** component is initialized. +
+This is used in Axis when running **gladevcp** under a tab with the EMBED_TAB_NAME/EMBED_TAB_COMMAND ini file feature.
+
+**gladevcp** supports gtkbuilder or libglade files though some widgets are not fully supported in gtkbuilder yet.
 
 == ISSUES
-For now system links need to be added in the glade library folders to point to our new widgets and catalog files. look in lib/python/gladevcp/READ_ME for details
+For now system links need to be added in the glade library folders to point to our new widgets and catalog files. 
+
+Look in lib/python/gladevcp/READ_ME for details
 

--- a/docs/man/man9/hal_pru_generic.asciidoc
+++ b/docs/man/man9/hal_pru_generic.asciidoc
@@ -8,10 +8,10 @@
 :man version : 
 
 == NAME
-hal_pru_generic - Machinekit HAL driver for the TI Programmable Realtime Unit (PRU).
+**hal_pru_generic** - Machinekit HAL driver for the TI Programmable Realtime Unit (PRU).
 
 == SYNOPSIS
-**loadrt hal_pru_generic [argument]...**
+**loadrt hal_pru_generic** __[argument]...__
 
 Valid arguments are:
 
@@ -38,10 +38,17 @@ results in a PRU task frequency of 100 KHz.  Smaller values here provide better
 timing performance for pwm and step/dir generators, but the setting must be
 large enough to allow all PRU tasks to complete.
 
-=== **halname** [optional, default: hal_pru_generic]
+=== **halname** [optional, default: **hal_pru_generic**]
 This identifier is used to prefix all created HAL pins and parameters.  The
-default is for legacy configurations and should otherwise be avoided.  Recent
-convention sets halname=hpg to provide for shorter HAL names.
+default is for legacy configurations and should otherwise be avoided.  
+
+==== NB
+You **MUST** set the name to a short one +
+Recent convention sets **halname=hpg** to provide for shorter HAL names.
+
+This is very important to do, because additions to HAL pins, mean some pins names
+will exceed a 49 charactor limit, if you use 15 charactors just for the base name.
+
 
 === **num_stepgens** [optional, default: 0]
 Create N stepgen instances.
@@ -58,7 +65,7 @@ state, which can be useful for debugging.  In this state, it is possible to
 single-step through the PRU startup code after the driver is loaded.
 
 == DESCRIPTION
-hal_pru_generic is a device driver that uses the PRU subsystem available
+**hal_pru_generic** is a device driver that uses the PRU subsystem available
 in Texas Instruments Sitara processors like on
 the BeagleBone SBC to perform high-speed hard-real-time bit-twiddling to
 generate step/direction and PWM outputs, avoiding the need to run a base
@@ -76,7 +83,7 @@ Currently, there are tasklets written for step/direction generation, PWM
 output, and encoder inputs (using direct PRU input pins).
 
 == I/O PINS
-The hal_pru_generic driver runs on a BeagleBone and has used a variety of
+The **hal_pru_generic** driver runs on a BeagleBone and has used a variety of
 numbering schemes to identify I/O pins.  All legacy pin numbering schemes
 are still supported for backwards compatibility, but are not documented here
 to avoid confusion (see fixup_pin() the code if you really need to know
@@ -119,8 +126,10 @@ utility.
 
 == STEPGEN
 
-stepgens have names like "hpg.stepgen.__<Instance>__".
-"Instance" is a two-digit number that corresponds to the stepgen
+stepgens have names like + 
+**"hpg.stepgen.__<Instance>__"**]
+
+__"Instance"__ is a two-digit number that corresponds to the stepgen
 instance number.  There are 'num_stepgens' instances, starting with 00.
 
 Each stepgen uses 2 IO pins, one for the step signal and one for the direction
@@ -168,7 +177,7 @@ change if the step timings or position-scale changes. Defaults to 0.
 per second.  Defaults to 1.0.  If set to 0, the driver will not limit its
 acceleration at all - this requires that the position-cmd or velocity-cmd
 pin is driven in a way that does not exceed the machine's capabilities.
-This is probably what you want if you're going to be using the LinuxCNC
+This is probably what you want if you're going to be using the Machinekit
 trajectory planner to jog or run G-code.
 
 *steplen* (u32 input):: Minimum duration of the step signal, in nanoseconds.
@@ -189,8 +198,10 @@ step ends, in nanoseconds.
 *stepinvert* (bit input):: Inverts the step output (normally high with pulses going low)
 
 == PWMGEN
-pwmgens have names like "hpg.pwmgen.__<Instance>__.out.__<Channel>__".
-"Instance" is a two-digit number that corresponds to the pwmgen
+pwmgens have names like +
+**"hpg.pwmgen.__<Instance>__.out.__<Channel>__"**
+
+__"Instance"__ is a two-digit number that corresponds to the pwmgen
 instance number.  Each channel number value passed to 'num_pwmgens'
 creates a pwmgen instance, starting with 00.  "Channel" is a two-digit
 number that corresponds to a specific pwmgen channel in a pwmgen
@@ -236,8 +247,10 @@ available but the lower the PWM frequency.
 
 
 == ENCODER
-Encoders have names like "hpg.encoder.__<Instance>__.out.__<Channel>__".
-"Instance" is a two-digit number that corresponds to the encoder
+Encoders have names like +
+**"hpg.encoder.__<Instance>__.out.__<Channel>__"**
+
+__"Instance"__ is a two-digit number that corresponds to the encoder
 instance number.  Each channel number value passed to 'num_encoders'
 creates an encoder instance, starting with 00.  "Channel" is a two-digit
 number that corresponds to a specific encoder channel in an encoder
@@ -256,11 +269,11 @@ Each encoder uses up to three PRU direct input pins, depending on the
 counting mode.
 
 WARNING: The encoder uses different pin numbering than the rest of the
-hal_pru_generic driver.  The pin number values for (A|B|index)-pin
+**hal_pru_generic** driver.  The pin number values for (A|B|index)-pin
 should be the PRU dedicated input pin number, a value in the range of
 0-16 inclusive.  It is the user's responsibility to insure the physical
 I/O pins used are available as direct PRU input pins on the PRU used
-to run the hal_pru_generic PRU binary.  Unused pins should be assigned
+to run the **hal_pru_generic** PRU binary.  Unused pins should be assigned
 to a PRU input that will not change value (the 'unconnected' inputs
 17-29 work well for this).
 

--- a/docs/man/man9/hm2_7i43.asciidoc
+++ b/docs/man/man9/hm2_7i43.asciidoc
@@ -8,11 +8,10 @@
 :man version : 
 
 == NAME
-hm2_7i43 - LinuxCNC HAL driver for the Mesa Electronics 7i43 EPP Anything IO board with HostMot2 firmware.
+**hm2_7i43** - Machinekit HAL driver for the Mesa Electronics 7i43 EPP Anything IO board with HostMot2 firmware.
 
 == SYNOPSIS
-**loadrt hm2_7i43 [ioaddr=**__N__**[,**__N__**...]] [ioaddr_hi=**__N__**[,**__N__**...]] [epp_wide=**__N__**[,**__N__**...]] [config=**__"str[,str...]"__**] [debug_epp=**__N__**[,**__N__**...]]
-**
+**loadrt hm2_7i43** __[ioaddr=**N**[,**N**...]] [ioaddr_hi=**N**[,**N**...]] [epp_wide=**N**[,**N**...]] [config=**"str[,str...]"**] [debug_epp=**N**[,**N**...]]__
 
 **ioaddr** [default: 0x378]
 
@@ -55,8 +54,8 @@ transfers.
 ====
 
 == DESCRIPTION
-hm2_7i43 is a device driver that interfaces the Mesa 7i43 board with
-the HostMot2 firmware to the LinuxCNC HAL.  Both the 200K and the 400K
+**hm2_7i43** is a device driver that interfaces the Mesa 7i43 board with
+the HostMot2 firmware to the Machinekit HAL.  Both the 200K and the 400K
 FPGAs are supported.
 
 The driver talks with the 7i43 over the parallel port, not over USB.  USB
@@ -71,9 +70,15 @@ in the **config** modparam, as described in the hostmot2(9) manpage,
 in the __config modparam__ section.
 
 Some parallel ports require special initialization before they can be
-used.  LinuxCNC provides a kernel driver that does this initialization
-called probe_parport.  Load this driver before loading hm2_7i43, by
-putting "loadrt probe_parport" in your .hal file.
+used.  Machinekit provides a kernel driver that does this initialization
+called probe_parport.  Load this driver before loading **hm2_7i43**, by
+putting this in your .hal file.
+[source, hal]
+----
+loadrt probe_parport
+----
+
+
 
 
 == Jumper settings
@@ -86,7 +91,7 @@ is active.  This is done by setting jumper W7 up, ie away from the edge
 of the board.
 
 == Communicating with the board
-The 7i43 communicates with the LinuxCNC computer over EPP, the Enhanced
+The 7i43 communicates with the Machinekit computer over EPP, the Enhanced
 Parallel Port.  This provides about 1 MBps of throughput, and the
 communication latency is very predictable and reasonably low.
 
@@ -94,13 +99,15 @@ The parallel port must support EPP 1.7 or EPP 1.9.  EPP 1.9 is prefered,
 but EPP 1.7 will work too.  The EPP mode of the parallel port is sometimes
 a setting in the BIOS.
 
-Note that the popular "NetMOS" aka "MosChip 9805" PCI parport cards **do
+Note that the very old "NetMOS" "MosChip 9805 and 9815" PCI parport cards **do
 **not work.  They do not meet the EPP spec, and cannot be reliably used
-with the 7i43.  You have to find another card, sorry.
+with the 7i43.  
+
+The later chips (eg. MCS9901) are claimed to meet EPP 1.9 and may be OK.
 
 EPP is very reliable under normal circumstances, but bad cabling
 or excessively long cabling runs may cause communication timeouts.
-The driver exports a parameter named hm2_7i43.<BoardNum>.io_error to
+The driver exports a parameter named **hm2_7i43**.<BoardNum>.io_error to
 inform HAL of this condition.  When the driver detects an EPP timeout,
 it sets io_error to True and stops communicating with the 7i43 board.
 Setting io_error back to False makes the driver start trying to

--- a/docs/man/man9/hm2_pci.asciidoc
+++ b/docs/man/man9/hm2_pci.asciidoc
@@ -8,18 +8,18 @@
 :man version : 
 
 == NAME
-hm2_pci - LinuxCNC HAL driver for the Mesa Electronics PCI-based Anything IO boards, with HostMot2 firmware.
+**hm2_pci** - Machinekit HAL driver for the Mesa Electronics PCI-based Anything IO boards, with HostMot2 firmware.
 
 
 == SYNOPSIS
-**loadrt hm2_pci [config=**__"str[,str...]"__**]**
+**loadrt hm2_pci** __[config=**"str[,str...]"**]__
 
-**config** [default: ""]
-HostMot2 config strings, described in the hostmot2(9) manpage.
+**config** __[default: ""]__
+HostMot2 config strings, described in the hostmot2 manpage.
 
 == DESCRIPTION
-hm2_pci is a device driver that interfaces Mesa's PCI and PC-104/Plus
-based Anything I/O boards (with the HostMot2 firmware) to the LinuxCNC
+**hm2_pci** is a device driver that interfaces Mesa's PCI and PC-104/Plus
+based Anything I/O boards (with the HostMot2 firmware) to the Machinekit
 HAL.
 
 The supported boards are: the 5i20, 5i22, and 5i23 (all on PCI); the

--- a/docs/man/man9/hostmot2.asciidoc
+++ b/docs/man/man9/hostmot2.asciidoc
@@ -8,7 +8,7 @@
 :man version : 
 
 == NAME
-hostmot2 - LinuxCNC HAL driver for the Mesa Electronics HostMot2 firmware.
+hostmot2 - Machinekit HAL driver for the Mesa Electronics HostMot2 firmware.
 
 
 == SYNOPSIS
@@ -51,7 +51,7 @@ Modules used.
 
 == DESCRIPTION
 hostmot2 is a device driver that interfaces the Mesa HostMot2 firmware
-to the LinuxCNC HAL.  This driver by itself does nothing, the boards
+to the Machinekit HAL.  This driver by itself does nothing, the boards
 that actually run the firmware require their own drivers before anything
 can happen.  Currently drivers are available for the 5i20, 5i22, 5i23,
 5i25, 3x20, 4i65, and 4i68 (all using the hm2_pci module) and the 7i43
@@ -143,7 +143,7 @@ The requested firmware F is fetched by udev.  udev searches for the
 firmware in the system's firmware search path, usually /lib/firmware.
 F typically has the form "hm2/<BoardType>/file.bit"; a typical value
 for F might be "hm2/5i20/SVST8_4.BIT".  The hostmot2 firmware files are
-supplied by the hostmot2-firmware packages, available from linuxcnc.org and can
+supplied by the hostmot2-firmware packages, available from machinekit.org and can
 normally be installed by entering the command "sudo apt-get install
 hostmot2-firmware-5i23" to install the support files for the 5i23 for example.
 
@@ -698,7 +698,7 @@ synchronous drive ratio between the encoder and the spindle or ballscrew.
 
 == BiSS
 BiSS is a bidirectional variant of SSI. Currently only a single direction is
-supported by LinuxCNC (encoder to PC). 
+supported by Machinekit (encoder to PC). 
 
 One pin is created for each BiSS instance regardless of data format:
 
@@ -714,7 +714,7 @@ function (described below)
 The names of the pins created by the BiSS module will depend entirely on the 
 format string for each channel specified in the loadrt command line and follow
 closely the format defined above for SSI. 
-Currently data packets of up to 96 bits are supported by the LinuxCNC driver, 
+Currently data packets of up to 96 bits are supported by the Machinekit driver, 
 although the Mesa Hostmot2 module can handle 512 bit packets. It should be
 possible to extend the number of packets supported by the driver if there is a
 requirement to do so. 
@@ -840,11 +840,11 @@ speed in rps, a value of 0.01666667 will give (approximate) RPM.
 ====
 The resolver component emulates an index at a fixed point in the sin/cos cycle.
 Some resolvers have multiple cycles per rev (often related to the number of
-pole-pairs on the attached motor). LinuxCNC requires an index once per
+pole-pairs on the attached motor). Machinekit requires an index once per
 revolution for proper threading etc.
 This parameter should be set to the number of cycles per rev of the resolver.
 CAUTION: Which pseudo-index is used will not necessarily be consistent between
-LinuxCNC runs. Do not expect to re-start a thread after restarting LinuxCNC.
+Machinekit runs. Do not expect to re-start a thread after restarting Machinekit.
 It is not appropriate to use this parameter for index-homing of axis drives.
 ====
 
@@ -1055,7 +1055,7 @@ fault pin unconnected.
 ====
 Sets the time during the cycle when an ADC pulse
 is generated.  0 = start of PWM cycle and 1 = end. Not currently useful
-to LinuxCNC. Default 0.5.
+to Machinekit. Default 0.5.
 ====
 
 In addition the per-instance parameters above there is the following parameter
@@ -1177,7 +1177,7 @@ Maximum acceleration, in position units per second
 per second.  Defaults to 1.0.  If set to 0, the driver will not limit its
 acceleration at all - this requires that the position-cmd or velocity-cmd
 pin is driven in a way that does not exceed the machine's capabilities.
-This is probably what you want if you're going to be using the LinuxCNC
+This is probably what you want if you're going to be using the Machinekit
 trajectory planner to jog or run G-code.
 ====
 

--- a/docs/man/man9/kins.asciidoc
+++ b/docs/man/man9/kins.asciidoc
@@ -9,7 +9,7 @@
 
 
 == NAME
-kins - kinematics definitions for LinuxCNC
+**kins** - kinematics definitions for Machinekit
 
 
 == SYNOPSIS
@@ -24,7 +24,7 @@ kins - kinematics definitions for LinuxCNC
 
 == DESCRIPTION
 Rather than exporting HAL pins and functions, these components provide the
-forward and inverse kinematics definitions for LinuxCNC.
+forward and inverse kinematics definitions for Machinekit.
 
 == trivkins - Trivial Kinematics
 There is a 1:1 correspondence between joints and axes.  Most standard milling
@@ -37,9 +37,9 @@ The X and Y axes are rotated 45 degrees compared to the joints 0 and 1.
 The joints represent the distance of the controlled point from three predefined
 locations (the motors), giving three degrees of freedom in position (XYZ)
 
-tripodkins.Bx
-tripodkins.Cx
-tripodkins.Cy
+tripodkins.Bx +
+tripodkins.Cx +
+tripodkins.Cy +
 The location of the three motors is (0,0), (Bx,0), and (Cx,Cy)
 
 == genhexkins - Hexapod Kinematics
@@ -48,23 +48,26 @@ location of the motors is defined at compile time.
 
 == maxkins - 5-axis kinematics example
 Kinematics for Chris Radek's tabletop 5 axis mill named 'max' with tilting
-head (B axis) and horizintal rotary mounted to the table (C axis).  Provides
-UVW motion in the rotated coordinate system.  The source file, maxkins.c,
-may be a useful starting point for other 5-axis systems.
+head (B axis) and horizintal rotary mounted to the table (C axis). +
+Provides UVW motion in the rotated coordinate system.  
+
+The source file, maxkins.c, may be a useful starting point for other 5-axis systems.
 
 == genserkins - generalized serial kinematics
 Kinematics that can model a general serial-link manipulator with up to 6
 angular joints.  
 
 The kinematics use Denavit-Hartenberg definition for the joint and
-links. The DH definitions are the ones used by John J Craig in
-"Introduction to Robotics: Mechanics and Control" The parameters for the
+links. +
+The DH definitions are the ones used by John J Craig in
+"Introduction to Robotics: Mechanics and Control" +
+The parameters for the
 manipulator are defined by hal pins.
 
-genserkins.A-__N
-__genserkins.ALPHA-__N
-__genserkins.D-__N
-__Parameters describing the __N__th joint's geometry.
+**genserkins**.A-__N__ +
+**genserkins**.ALPHA-__N__ +
+**genserkins**.D-__N__ +
+are parameters describing the __N__th joint's geometry.
 
 == pumakins - kinematics for puma typed robots
 Kinematics for a puma-style robot with 6 joints
@@ -83,7 +86,7 @@ Describe the geometry of the robot
 Vertical distance from the ground plane to the center of the inner arm.
 
 === scarakins.D2
-Horizontal distance between joint[0] axis and joint[1] axis, ie.  the
+Horizontal distance between **joint[0]** axis and **joint[1]** axis, ie.  the
 length of the inner arm.
 
 === scarakins.D3
@@ -92,7 +95,7 @@ outer arm.  May be positive or negative depending on the structure of
 the robot.
 
 === scarakins.D4
-Horizontal distance between joint[1] axis and joint[2] axis, ie.  the
+Horizontal distance between **joint[1]** axis and **joint[2]** axis, ie.  the
 length of the outer arm.
 
 === scarakins.D5
@@ -100,10 +103,9 @@ Vertical distance from the end effector to the tooltip.  Positive means
 the tooltip is lower than the end effector, and is the normal case.
 
 === scarakins.D6
-Horizontal distance from the centerline of the end effector (and the
-joints 2 and 3 axis) and the tooltip.  Zero means the tooltip is on the
-centerline.  Non-zero values should be positive, if negative they
-introduce a 180 degree offset on the value of joint[3].
+Horizontal distance from the centerline of the end effector (and **joint[2] and **joint[3]** axis) and the tooltip. +
+Zero means the tooltip is on the centerline. + 
+Non-zero values should be positive, if negative they introduce a 180 degree offset on the value of joint[3].
 
 == SEE ALSO
 __Kinematics__ section in the Machinekit documentation

--- a/docs/man/man9/lcd.asciidoc
+++ b/docs/man/man9/lcd.asciidoc
@@ -8,14 +8,14 @@
 :man version : 
 
 == NAME
-lcd - Stream HAL data to an LCD screen
+**lcd** - Stream HAL data to an LCD screen
 
 == SYNOPSIS
-loadrt lcd fmt_strings=""Plain Text %4.4f\enAnd So on|Second Page, Next Inst""
+**loadrt lcd** __fmt_strings=""Plain Text %4.4f\enAnd So on|Second Page, Next Inst""__
 
 == FUNCTIONS
-**lcd** (requires a floating-point thread). All LCD instances are updated by the
-same function. 
+**lcd** (requires a floating-point thread). +
+All LCD instances are updated by the same function. 
 
 == PINS
 **lcd.**__NN__**.out** (u32) out

--- a/docs/man/man9/lineardeltakins.asciidoc
+++ b/docs/man/man9/lineardeltakins.asciidoc
@@ -8,16 +8,16 @@
 :man version : 
 
 == NAME
-lineardeltakins - Kinematics for a linear delta robot
+**lineardeltakins** - Kinematics for a linear delta robot
 
 == SYNOPSIS
-loadrt lineardeltakins
+**loadrt lineardeltakins**
 
 == KINEMATICS
 The kinematics model is appropriate for a rostock/kossel-style design
 with three joints arranged in an equilateral triangle.  (0,0) is always
-the center of the working volume.  Joint 0 is at (0,R) and subsequent
-joints are 120 degrees clockwise (note that joint 0 is not at zero
+the center of the working volume. +
+Joint 0 is at (0,R) and subsequent joints are 120 degrees clockwise (note that joint 0 is not at zero
 radians).  The length of the arm is L.
 
 Joints 0-2 are the linear carriages.  Axes ABC and UVW are passed
@@ -25,49 +25,53 @@ through unchanged in joints 3-8, so that e.g., A can still be used to
 control an extruder.
 
 Three pins have been provided for joints 0-2, to allow for offset trimming 
-during calibration. It is suggested that these pins are only used during 
+during calibration. +
+It is suggested that these pins are only used during 
 calibration to determine the proper distance between the work surface and 
-the limit switches for each joint. Once the proper distance has been determined 
-The pins should be set to zero and update each joints home parameters in the INI
+the limit switches for each joint. +
+Once the proper distance has been determined 
+the pins should be set to zero and update each joints home parameters in the INI
 file.
  
 == PINS
 
-lineardeltakins.R float in
+**lineardeltakins**.__R__ float in
 
 [indent=4]
 ====
 Effective diameter of the platform.
 
-R is different than the distance from the center of the table to the
-center of the belt/smooth rod/extrusion that the joints ride on. In
-RepRap delta parlance, R is DELTA_RADIUS which is computed as
+__R__ is different than the distance from the center of the table to the
+center of the belt/smooth rod/extrusion that the joints ride on. 
+
+InRepRap delta parlance, R is DELTA_RADIUS which is computed as
 DELTA_SMOOTH_ROD_OFFSET-DELTA_EFFECTOR_OFFSET-DELTA_CARRIAGE_OFFSET.
 ====
 
-lineardeltakins.L float in
+**lineardeltakins**.__L__ float in
 
 [indent=4]
 ====
-Length of the rod connecting the carriage to the effector.  In RepRap
-delta parlance, L is DELTA_DIAGONAL_ROD
+Length of the rod connecting the carriage to the effector.  
+
+In RepRap delta parlance, __L__ is DELTA_DIAGONAL_ROD
 ====
 
-lineardeltakins.J0offs float in
+**lineardeltakins**.__J0offs__ float in
 
 [indent=4]
 ====
 Offset distance applied to Joint 0
 ====
 
-lineardeltakins.J1offs float in
+**lineardeltakins**.__J1offs__ float in
 
 [indent=4]
 ====
 Offset distance applied to Joint 1
 ====
 
-lineardeltakins.J2offs float in
+**lineardeltakins**.__J2offs__ float in
 
 [indent=4]
 ====
@@ -75,7 +79,8 @@ Offset distance applied to Joint 2
 ====
 
 == NOTES
-The R and L and joint offset values can be adjusted while Machinekit is running.
+The __R__ and __L__ and joint offset values can be adjusted while Machinekit is running.
+
 However, doing so while in coordinated mode will lead to a step change in joint
 position, which generally will trigger a following error if in joint
 mode with machine on.

--- a/docs/man/man9/matrix_kb.asciidoc
+++ b/docs/man/man9/matrix_kb.asciidoc
@@ -8,14 +8,15 @@
 :man version : 
 
 == NAME
-matrix_kb - Convert integers to HAL pins. Optionally scan a matrix of IO ports
-to create those integers.  
+**matrix_kb** - Convert integers to HAL pins. 
+
+Optionally scan a matrix of IO ports to create those integers.  
 
 
 == SYNOPSIS
-**loadrt matrix_kb config=**__RxCs,RxCs__**... names=**__name1,name2__**...
-**.P
-Creates a component configured for R rows and N columns of matrix keyboard. 
+**loadrt matrix_kb __config=**RxCs,RxCs**... names=**name1,name2**...__
+
+Creates a component configured for R rows and C columns of matrix keyboard. 
 
 If the **s** option is specified then a set of output rows will be cyclically
 toggled, and a set of input columns will be scanned. 


### PR DESCRIPTION
The first few ones at least were largely OK.

Mostly edited for consistency of formatting and appearence
plus a couple of factual updates, instances of 'Linuxcnc',  occasional stray troff formatting etc

Signed-off-by: Mick <arceye@mgware.co.uk>