### PR TITLE
Re-format /man/man9 rtapi_ for readability and remove troff

### DIFF
--- a/docs/man/man3/intro_hal.asciidoc
+++ b/docs/man/man3/intro_hal.asciidoc
@@ -10,66 +10,86 @@
 
 == NAME
 
-hal -- Introduction to the HAL API
+**HAL** -- Introduction to the HAL API
 
 
 
 == DESCRIPTION
 
-HAL stands for Hardware Abstraction Layer, and is used by LinuxCNC to transfer
+**HAL** stands for Hardware Abstraction Layer, and is used by LinuxCNC to transfer
 realtime data to and from I/O devices and other low-level modules.
 
-**hal.h** defines the API and data structures used by the HAL.  This file is
-included in both realtime and non-realtime HAL components.  HAL uses the RTPAI
+**hal.h** defines the API and data structures used by the **HAL**.  +
+This file is
+included in both realtime and non-realtime **HAL** components.  +
+**HAL** uses the RTPAI
 real time interface, and the #define symbols RTAPI and ULAPI are used to
-distinguish between realtime and non-realtime code.  The API defined in this
+distinguish between realtime and non-realtime code.  +
+The API defined in this
 file is implemented in hal_lib.c and can be compiled for linking to either
-realtime or user space HAL components.  
+realtime or user space **HAL** components.  
 
-The HAL is a very modular approach to the low level parts of a motion control
-system.  The goal of the HAL is to allow a systems integrator to connect a
+The **HAL** is a very modular approach to the low level parts of a motion control
+system.  +
+The goal of the **HAL** is to allow a systems integrator to connect a
 group of software components together to meet whatever I/O requirements he (or
-she) needs.  This includes realtime and non-realtime I/O, as well as basic
-motor control up to and including a PID position loop.  What these functions
-have in common is that they all process signals.  In general, a signal is a
-data item that is updated at regular intervals.  For example, a PID loop gets
+she) needs.  +
+This includes realtime and non-realtime I/O, as well as basic
+motor control up to and including a PID position loop.  +
+What these functions
+have in common is that they all process signals.  +
+In general, a signal is a
+data item that is updated at regular intervals.  +
+For example, a PID loop gets
 position command and feedback signals, and produces a velocity command signal.  
 
-HAL is based on the approach used to design electronic circuits.  In
+**HAL** is based on the approach used to design electronic circuits.  +
+In
 electronics, off-the-shelf components like integrated circuits are placed on a
 circuit board and their pins are interconnected to build whatever overall
-function is needed.  The individual components may be as simple as an op-amp,
-or as complex as a digital signal processor.  Each component can be
-individually tested, to make sure it works as designed.  After the components
+function is needed.  +
+The individual components may be as simple as an op-amp,
+or as complex as a digital signal processor.  +
+Each component can be
+individually tested, to make sure it works as designed.  +
+After the components
 are placed in a larger circuit, the signals connecting them can still be
 monitored for testing and troubleshooting.
 
-Like electronic components, HAL components have pins, and the pins can be
+Like electronic components, **HAL** components have pins, and the pins can be
 interconnected by signals.
 
-In the HAL, a __signal__ contains the actual data value that passes from one pin
-to another.  When a signal is created, space is allocated for the data value.
-A __pin__ on the other hand, is a pointer, not a data value.  When a pin is
+In the **HAL**, a __signal__ contains the actual data value that passes from one pin
+to another.  +
+When a signal is created, space is allocated for the data value. +
+A __pin__ on the other hand, is a pointer, not a data value.  +
+When a pin is
 connected to a signal, the pin's pointer is set to point at the signal's data
-value.  This allows the component to access the signal with very little
+value.  +
+This allows the component to access the signal with very little
 run-time overhead.  (If a pin is not linked to any signal, the pointer points
 to a dummy location, so the realtime code doesn't have to deal with null
 pointers or treat unlinked variables as a special case in any way.)
 
-There are three approaches to writing a HAL component.  Those that do not
-require hard realtime performance can be written as a single user mode process.
+There are three approaches to writing a **HAL** component.  +
+Those that do not
+require hard realtime performance can be written as a single user mode process. +
 Components that need hard realtime performance but have simple configuration
 and init requirements can be done as a single kernel module, using either
-pre-defined init info, or insmod-time parameters.  Finally, complex components
+pre-defined init info, or insmod-time parameters.  +
+Finally, complex components
 may use both a kernel module for the realtime part, and a user space process to
 handle ini file access, user interface (possibly including GUI features), and
 other details.
 
-HAL uses the RTAPI/ULAPI interface.  If RTAPI is #defined hal_lib.c would
+**HAL** uses the RTAPI/ULAPI interface.  +
+If RTAPI is #defined hal_lib.c would
 generate a kernel module hal_lib.o that is insmoded and provides the functions
-for all kernel module based components.  The same source file compiled with the
+for all kernel module based components.  +
+The same source file compiled with the
 ULAPI #define would make a user space hal_lib.o that is staticlly linked to
-user space code to make user space executables.  The variable lists and link
+user space code to make user space executables.  +
+The variable lists and link
 information are stored in a block of shared memory and protected with mutexes,
 so that kernel modules and any of several user mode programs can access the
 data.
@@ -77,7 +97,7 @@ data.
 
 
 == REALTIME CONSIDERATIONS
-For an explanation of realtime considerations, see **intro**.
+For an explanation of realtime considerations, see **intro_rtapi**.
 
 
 
@@ -88,4 +108,4 @@ for errors, and nonnegative values for success.
 
 
 == SEE ALSO
-**intro**
+**intro_rtapi**

--- a/docs/man/man3/intro_rtapi.asciidoc
+++ b/docs/man/man3/intro_rtapi.asciidoc
@@ -10,74 +10,79 @@
 
 == NAME
 
-rtapi -- Introduction to the RTAPI API
+**rtapi** -- Introduction to the RTAPI API
 
 
 
 == DESCRIPTION
-RTAPI is a library providing a uniform API for several real time operating
-systems.  As of ver 2.1, RTLinux, RTAI, and a pure userspace simulator are
-supported.
-
+**RTAPI** is a library providing a uniform API for several real time operating
 
 
 == HEADER FILES
-.SS rtapi.h
-The file **rtapi.h** defines the RTAPI for both realtime and non-realtime
-code.  This is a change from Rev 2, where the non-realtime (user space) API
-was defined in ulapi.h and used different function names.  The symbols RTAPI
-and ULAPI are used to determine which mode is being compiled, RTAPI for
+
+=== rtapi.h
+The file **rtapi.h** defines the **RTAPI** for both realtime and non-realtime
+code.  +
+This is a change from Rev 2, where the non-realtime (user space) API
+was defined in **ulapi.h** and used different function names.  +
+The symbols **RTAPI**
+and ULAPI are used to determine which mode is being compiled, **RTAPI** for
 realtime and ULAPI for non-realtime.
 
-.SS rtapi_math.h
-The file rtapi_math.h defines floating-point functions and constants.
-It should be used instead of <math.h> in rtapi real-time components.
+=== rtapi_math.h
+The file **rtapi_math.h** defines floating-point functions and constants.
+It should be used instead of **<math.h>** in rtapi real-time components.
 
 
-.SS rtapi_string.h
-The file rtapi_string.h defines string-related functions.
-It should be used instead of <string.h> in rtapi real-time components.
+=== rtapi_string.h
+The file **rtapi_string.h** defines string-related functions. +
+It should be used instead of **<string.h>** in rtapi real-time components.
 
-.SS rtapi_byteorder.h
+=== rtapi_byteorder.h
 This file defines the preprocessor macros RTAPI_BIG_ENDIAN,
 RTAPI_LITTLE_ENDIAN, and RTAPI_FLOAT_BIG_ENDIAN as true or false depending on
-the characteristics of the target system.  It should be used instead of
+the characteristics of the target system.  +
+It should be used instead of
 **<endian.h>** (userspace) or **<linux/byteorder.h>** (kernel space).
 
-.SS rtapi_limits.h
+=== rtapi_limits.h
 This file defines the minimum and maximum value of some fundamental integral
-types, such as INT_MIN and INT_MAX.  This should be used instead of
+types, such as INT_MIN and INT_MAX.  +
+This should be used instead of
 **<limits.h>** because that header file is not available to kernel modules.
 
 
 
 == REALTIME CONSIDERATIONS
-.SS Userspace code
-Certain functions are not available in userspace code.  This includes functions
+=== Userspace code
+Certain functions are not available in userspace code.  +
+This includes functions
 that perform direct device access such as **rtapi_inb**.
 
-.SS Init/cleanup code
-Certain functions may only be called from realtime init/cleanup code.
+=== Init/cleanup code
+Certain functions may only be called from realtime init/cleanup code. +
 This includes functions that perform memory allocation, such as
 **rtapi_shmem_new**.
 
-.SS Realtime code
-Only a few functions may be called from realtime code.  This includes
-functions that perform direct device access such as **rtapi_inb**.
+=== Realtime code
+Only a few functions may be called from realtime code.  +
+This includes
+functions that perform direct device access such as **rtapi_inb**. +
 It excludes most Linux kernel APIs such as do_gettimeofday and
-many rtapi APIs such as rtapi_shmem_new.
+many rtapi APIs such as **rtapi_shmem_new**.
 
-.SS Simulator
-For an RTAPI module to be buildable in the "sim" environment (fake realtime
+=== Simulator
+For an **RTAPI** module to be buildable in the "sim" environment (fake realtime
 system without special privileges), it must not use **any** linux kernel
-APIs, and must not use the RTAPI APIs for direct device access such as
-**rtapi_inb**.  This automatically includes any hardware device drivers,
+APIs, and must not use the **RTAPI** APIs for direct device access such as
+**rtapi_inb**.  +
+This automatically includes any hardware device drivers,
 and also devices which use Linux kernel APIs to do things like create
 special devices or entries in the **/proc** filesystem.
 
 
 
 == RTAPI STATUS CODES
-Except as noted in specific manual pages, RTAPI returns negative errno values
+Except as noted in specific manual pages, **RTAPI** returns negative errno values
 for errors, and nonnegative values for success.
 

--- a/docs/man/man3/rtapi_app_exit.asciidoc
+++ b/docs/man/man3/rtapi_app_exit.asciidoc
@@ -10,12 +10,12 @@
 
 == NAME
 
-rtapi_app_exit -- User-provided function to shut down a component
+**rtapi_app_exit** -- User-provided function to shut down a component
 
 
 
 == SYNTAX
-void **rtapi_app_exit**(void) { __...__ }
+**void rtapi_app_exit**( **void** ) { __...__ }
 
 
 == ARGUMENTS
@@ -29,7 +29,8 @@ generally consists of a call to rtapi_exit or hal_exit, preceded by other
 component-specific shutdown code.
 
 This code is called when unloading a component which successfully initialized
-(i.e., returned zero from its **rtapi_app_main**).  It is not called when
+(i.e., returned zero from its **rtapi_app_main**).  +
+It is not called when
 the component did not successfully initialize.
 
 
@@ -46,6 +47,6 @@ realtime) context.
 
 
 == SEE ALSO
-**rtapi_app_main**,
-**rtapi_exit**,
+**rtapi_app_main** +
+**rtapi_exit** +
 **hal_exit**

--- a/docs/man/man3/rtapi_app_main.asciidoc
+++ b/docs/man/man3/rtapi_app_main.asciidoc
@@ -10,13 +10,14 @@
 
 == NAME
 
-rtapi_app_main -- User-provided function to initialize a component
+**rtapi_app_main** -- User-provided function to initialize a component
 
 
 
 == SYNTAX
-#include "rtapi_app.h"
-int **rtapi_app_main**(void) { __...__ }
+__#include "rtapi_app.h"__
+
+**int rtapi_app_main**( **void** ) { __...__ }
 
 
 == ARGUMENTS
@@ -33,7 +34,8 @@ component-specific initialization code.
 
 == RETURN VALUE
 Return 0 for success.  Return a negative errno value (e.g., -EINVAL) on
-error.  Existing code also returns RTAPI or HAL error values, but using
+error.  +
+xisting code also returns RTAPI or HAL error values, but using
 negative errno values gives better diagnostics from insmod.
 
 
@@ -45,6 +47,6 @@ realtime) context.
 
 
 == SEE ALSO
-**rtapi_app_exit**,
-**rtapi_init**,
+**rtapi_app_exit** +
+**rtapi_init** +
 **hal_init**

--- a/docs/man/man3/rtapi_clock_set_period.asciidoc
+++ b/docs/man/man3/rtapi_clock_set_period.asciidoc
@@ -10,33 +10,44 @@
 
 == NAME
 
-rtapi_clock_set_period -- set the basic time interval for realtime tasks
+**rtapi_clock_set_period** -- set the basic time interval for realtime tasks
 
 
 
 == SYNTAX
- rtapi_clock_set_period(long int __nsec__)
+__#include "rtapi.h"__
+
+**rtapi_clock_set_period** ( **long int** __nsec__)
 
 
 
 == ARGUMENTS
-.IP __nsec__**
-**The desired basic time interval for realtime tasks.
+__nsec__ +
+The desired basic time interval for realtime tasks.
 
 
 
 == DESCRIPTION
-**rtapi_clock_set_period** sets the basic time interval for realtime tasks.
-All periodic tasks will run at an integer multiple of this period.  The first
+**rtapi_clock_set_period** sets the basic time interval for realtime tasks. +
+All periodic tasks will run at an integer multiple of this period.  
+
+The first
 call to **rtapi_clock_set_period** with __nsec__ greater than zero will
-start the clock, using __nsec__ as the clock period in nano-seconds.  Due to
+start the clock, using __nsec__ as the clock period in nano-seconds.  +
+Due to
 hardware and RTOS limitations, the actual period may not be exactly what was
-requested.  On success, the function will return the actual clock period if it
-is available, otherwise it returns the requested period.  If the requested
+requested.  +
+On success, the function will return the actual clock period if it
+is available, otherwise it returns the requested period.  
+
+If the requested
 period is outside the limits imposed by the hardware or RTOS, it returns
-**-EINVAL** and does not start the clock.  Once the clock is started,
+**-EINVAL** and does not start the clock.  
+
+Once the clock is started,
 subsequent calls with non-zero __nsec__ return **-EINVAL** and have no
-effect.  Calling **rtapi_clock_set_period** with __nsec__ set to zero
+effect.  +
+Calling **rtapi_clock_set_period** with __nsec__ set to zero
 queries the clock, returning the current clock period, or zero if the clock has
 not yet been started.  
 

--- a/docs/man/man3/rtapi_delay.asciidoc
+++ b/docs/man/man3/rtapi_delay.asciidoc
@@ -10,32 +10,37 @@
 
 == NAME
 
-rtapi_delay -- Busy-loop for short delays
+**rtapi_delay** -- Busy-loop for short delays
 
 
 
 == SYNTAX
-void rtapi_delay(long int __nsec__)
-void rtapi_delay_max()
+__#include "rtapi.h"__
+
+**void rtapi_delay** ( **long int** __nsec__ ) +
+**long int rtapi_delay_max**()
 
 
 
 == ARGUMENTS
-.IP __nsec__
+__nsec__ +
 The desired delay length in nanoseconds
 
 
 
 == DESCRIPTION
-**rtapi_delay** is a simple delay.  It is intended only for short
+**rtapi_delay** is a simple delay.  +
+t is intended only for short
 delays, since it simply loops, wasting CPU cycles.
 
 **rtapi_delay_max** returns the max delay permitted (usually
-approximately 1/4 of the clock period).  Any call to **rtapi_delay**
+approximately 1/4 of the clock period).  +
+Any call to **rtapi_delay**
 requesting a delay longer than the max will delay for the max time only.
 
 **rtapi_delay_max** should be called before using **rtapi_delay** to
-make sure the required delays can be achieved.  The actual resolution
+make sure the required delays can be achieved.  +
+The actual resolution
 of the delay may be as good as one nano-second, or as bad as a several
 microseconds.
 
@@ -47,8 +52,8 @@ May be called from init/cleanup code, and from within realtime tasks.
 
 
 == RETURN VALUE
-**rtapi_delay_max returns the maximum delay permitted.
-**
+**rtapi_delay_max** returns the maximum delay permitted.
+
 
 
 == SEE ALSO

--- a/docs/man/man3/rtapi_div_u64.asciidoc
+++ b/docs/man/man3/rtapi_div_u64.asciidoc
@@ -3,21 +3,7 @@
 :skip-front-matter:
 
 = rtapi_div_u64
-\" Copyright (C) 2013 Jeff Epler <jepler@unpythonic.net>
-\"
-\" This program is free software; you can redistribute it and/or
-\" modify it under the terms of the GNU General Public License
-\" as published by the Free Software Foundation; either version 2
-\" of the License, or (at your option) any later version.
-\"
-\" This program is distributed in the hope that it will be useful,
-\" but WITHOUT ANY WARRANTY; without even the implied warranty of
-\" MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-\" GNU General Public License for more details.
-\"
-\" You should have received a copy of the GNU General Public License
-\" along with this program; if not, write to the Free Software
-\" Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
 :manmanual: HAL Components
 :mansource: ../man/man3/rtapi_div_u64.asciidoc
 :man version : 
@@ -25,26 +11,33 @@
 
 == NAME
 
-rtapi_div_u64 -- unsigned division of a 64-bit number by a 32-bit number
+**rtapi_div_u64** -- unsigned division of a 64-bit number by a 32-bit number
 
 
 
 == SYNTAX
-__u64 rtapi_div_u64_rem(__u64 __dividend__, __u32 __divisor__, __u32 *__remainder__)
-__u64 rtapi_div_u64(__u64 __dividend__, __u32 __divisor__)
-__s64 rtapi_div_s64(__s64 __dividend__, __s32 __divisor__)
-__s64 rtapi_div_s64_rem(__s64 __dividend__, __s32 __divisor__, __s32 *__remainder__)
+**__u64 rtapi_div_u64_rem** ( **__u64** __dividend__, **__u32** __divisor__, **__u32** *__remainder__)
+
+**__u64 rtapi_div_u64** ( **__u64** __dividend__, **__u32** __divisor__)
+
+**__s64 rtapi_div_s64** ( **__s64** __dividend__, **__s32** __divisor__)
+
+**__s64 rtapi_div_s64_rem** ( **__s64** __dividend__, **__s32** __divisor__, **__s32** *__remainder__)
 
 
 
 == ARGUMENTS
-.IP __dividend__
+__dividend__ +
 The value to be divided
-.IP __divisor__
+
+__divisor__ +
 The value to divide by
-.IP __remainder__
-Pointer to the location to store the remainder.  This may not be a NULL
-pointer.  If the remainder is not desired, call **rtapi_div_u64** or
+
+__remainder__ +
+Pointer to the location to store the remainder.  +
+This may not be a NULL
+pointer.  +
+If the remainder is not desired, call **rtapi_div_u64** or
 **rtapi_div_s64**.
 
 
@@ -57,14 +50,18 @@ Perform integer division (and optionally compute the remainder) with a 64-bit di
 == RETURN VALUE
 The result of integer division of __dividend / divisor__.  In versions with the __remainder__ argument, the remainder is stored in the pointed-to location.
 
+== AUTHOR
+Jeff Epler
 
+== LICENCE
+GPL2 or higher
 
 == NOTES
 If the result of the division does not fit in the return type, the result is
 undefined.
 
 This function exists because in kernel space the use of the division operator
-on a 64-bit type can lead to an undefined symbol such as __umoddi3 when the
+on a 64-bit type can lead to an undefined symbol such as **__umoddi3** when the
 module is loaded.
 
 

--- a/docs/man/man3/rtapi_exit.asciidoc
+++ b/docs/man/man3/rtapi_exit.asciidoc
@@ -10,23 +10,26 @@
 
 == NAME
 
-rtapi_exit -- Shut down RTAPI
+**rtapi_exit** -- Shut down RTAPI
 
 
 
 == SYNTAX
- int rtapi_exit(int __module_id__)
+__#include "rtapi.h"__
+
+**int rtapi_exit** ( **int** __module_id__ )
 
 
 
 == ARGUMENTS
-.IP __module_id__
+__module_id__ +
 An rtapi module identifier returned by an earlier call to **rtapi_init**.
 
 
 
 == DESCRIPTION
-**rtapi_exit** shuts down and cleans up the RTAPI.  It must be
+**rtapi_exit** shuts down and cleans up the RTAPI.  +
+It must be
 called prior to exit by any module that called **rtapi_init**.
 
 

--- a/docs/man/man3/rtapi_get_time.asciidoc
+++ b/docs/man/man3/rtapi_get_time.asciidoc
@@ -10,49 +10,63 @@
 
 == NAME
 
-rtapi_get_time -- get the current time
+**rtapi_get_time** -- get the current time
 
 
 
 == SYNTAX
-long long rtapi_get_time()
-long long rtapi_get_clocks()
+**long long rtapi_get_time**()
 
+**long long rtapi_get_clocks**()
 
 
 == DESCRIPTION
-**rtapi_get_time** returns the current time in nanoseconds.  Depending on the
+**rtapi_get_time** returns the current time in nanoseconds.  +
+Depending on the
 RTOS, this may be time since boot, or time since the clock period was set, or
-some other time.  Its absolute value means nothing, but it is monotonically
+some other time.  
+
+Its absolute value means nothing, but it is monotonically
 increasing and can be used to schedule future events, or to time the duration
-of some activity.  Returns a 64 bit value.  The resolution of the returned
-value may be as good as one nano-second, or as poor as several microseconds.
+of some activity.  Returns a 64 bit value.  +
+The resolution of the returned
+value may be as good as one nano-second, or as poor as several microseconds.+
 May be called from init/cleanup code, and from within realtime tasks.  
 
-**rtapi_get_clocks** returns the current time in CPU clocks.  It is 
+**rtapi_get_clocks** returns the current time in CPU clocks.  +
+It is 
 fast, since it just reads the TSC in the CPU instead of calling a
-kernel or RTOS function.  Of course, times measured in CPU clocks
+kernel or RTOS function.  +
+Of course, times measured in CPU clocks
 are not as convenient, but for relative measurements this works
-fine.  Its absolute value means nothing, but it is monotonically
+fine.  
+
+Its absolute value means nothing, but it is monotonically
 increasing and can be used to schedule future events, or to time
 the duration of some activity.  (on SMP machines, the two TSC's
 may get out of sync, so if a task reads the TSC, gets swapped to
 the other CPU, and reads again, the value may decrease.  RTAPI
 tries to force all RT tasks to run on one CPU.)
+
 Returns a 64 bit value.  The resolution of the returned value is
 one CPU clock, which is usually a few nanoseconds to a fraction of
 a nanosecond. 
     
 Note that __long long__ math may be poorly supported on some platforms,
-especially in kernel space. Also note that rtapi_print() will NOT
+especially in kernel space. +
+Also note that rtapi_print() will NOT
 print __long long__s.  Most time measurements are relative, and should
 be done like this:
-.RS
+[source, C]
+----
 deltat = (long int)(end_time - start_time);
-.RE
+----
 where end_time and start_time are longlong values returned from rtapi_get_time,
-and deltat is an ordinary long int (32 bits).  This will work for times up to a
-second or so, depending on the CPU clock frequency.  It is best used for
+and deltat is an ordinary long int (32 bits).  
+
+This will work for times up to a
+second or so, depending on the CPU clock frequency.  +
+It is best used for
 millisecond and microsecond scale measurements though.
 
 
@@ -64,13 +78,18 @@ Returns the current time in nanoseconds or CPU clocks.
 == NOTES
 Certain versions of the Linux kernel provide a global variable **cpu_khz**.
 Computing 
-.RS
+[source, C]
+----
 	deltat = (end_clocks - start_clocks) / cpu_khz:
-.RE
-gives the duration measured in milliseconds.  Computing
-.RS
+----
+gives the duration measured in milliseconds.  
+
+Computing
+[source, C]
+----
 	deltat = (end_clocks - start_clocks) * 1000000 / cpu_khz:
-.RE
+----
+
 gives the duration measured in nanoseconds for deltas less than about 9
 trillion clocks (e.g., 3000 seconds at 3GHz).
 

--- a/docs/man/man3/rtapi_init.asciidoc
+++ b/docs/man/man3/rtapi_init.asciidoc
@@ -10,33 +10,32 @@
 
 == NAME
 
-rtapi_init -- Sets up RTAPI
+**rtapi_init** -- Sets up RTAPI
 
 
 
 == SYNTAX
- int rtapi_init(const char *__modname__, global_data_t global**)
+**int rtapi_init** ( **const char** *__modname__ )
 
 
 
 == ARGUMENTS
-.IP __modname__
-The name of this rtapi module
-.IP __global__
-reference to the global data segment. Can be NULL if unused.
-
-
+__modname__ +
+module name string
 
 
 == DESCRIPTION
 
-**rtapi_init** sets up the RTAPI.  It must be called by any
+**rtapi_init** sets up the RTAPI.  +
+It must be called by any
 module that intends to use the API, before any other RTAPI
 calls.
 
 __modname__ can optionally point to a string that identifies
-the module.  The string will be truncated at **RTAPI_NAME_LEN**
-characters.  If __modname__ is **NULL**, the system will assign a
+the module.  +
+The string will be truncated at **RTAPI_NAME_LEN**
+characters.  +
+If __modname__ is **NULL**, the system will assign a
 name.
 
 
@@ -49,4 +48,5 @@ Call only from within user or init/cleanup code, not from realtime tasks.
 == RETURN VALUE
 On success, returns a positive integer module ID, which is
 used for subsequent calls to rtapi_xxx_new, rtapi_xxx_delete,
-and rtapi_exit.  On failure, returns an RTAPI error code.
+and rtapi_exit.  +
+On failure, returns an RTAPI error code.

--- a/docs/man/man3/rtapi_module_param.asciidoc
+++ b/docs/man/man3/rtapi_module_param.asciidoc
@@ -10,87 +10,87 @@
 
 == NAME
 
-rtapi_module_param -- Specifying module parameters
+**rtapi_module_param** -- Specifying module parameters
 
 
 
 == SYNTAX
-RTAPI_MP_INT(__var__, __description__)
 
-RTAPI_MP_LONG(__var__, __description__)
+**RTAPI_MP_INT**(__var__, __description__)
 
-RTAPI_MP_STRING(__var__, __description__)
+**RTAPI_MP_LONG**(__var__, __description__)
 
-RTAPI_MP_ARRAY_INT(__var__, __num__, __description__)
+**RTAPI_MP_STRING**(__var__, __description__)
 
-RTAPI_MP_ARRAY_LONG(__var__, __num__, __description__)
+**RTAPI_MP_ARRAY_INT**(__var__, __num__, __description__)
 
-RTAPI_MP_ARRAY_STRING(__var__, __num__, __description__)
+**RTAPI_MP_ARRAY_LONG**(__var__, __num__, __description__)
 
-MODULE_LICENSE(__license__)
+**RTAPI_MP_ARRAY_STRING**(__var__, __num__, __description__)
 
-MODULE_AUTHOR(__author__)
+**MODULE_LICENSE**(__license__)
 
-MODULE_DESCRIPTION(__description__)
+**MODULE_AUTHOR**(__author__)
 
-EXPORT_FUNCTION(__function__)
+**MODULE_DESCRIPTION**(__description__)
+
+**EXPORT_FUNCTION**(__function__)
 
 
 
 == ARGUMENTS
-.IP __var__
+__var__ +
 The variable where the parameter should be stored
-.IP __description__
+
+__description__ +
 A short description of the parameter or module
-.IP __num__
+
+__num__ +
 The maximum number of values for an array parameter
-.IP __license__
+
+__license__ +
 The license of the module, for instance "GPL"
-.IP __author__
+
+__author__ +
 The author of the module
-.IP __function__
+
+__function__ +
 The pointer to the function to be exported
 
 
 
 == DESCRIPTION
-These macros are portable ways to declare kernel module parameters.  They must
-be used in the global scope, and are not followed by a terminating semicolon.
+These macros are portable ways to declare kernel module parameters.  +
+They must
+be used in the global scope, and are not followed by a terminating semicolon. +
 They must be used after the associated variable or function has been defined.
 
 
 
 == NOTES
 EXPORT_FUNCTION makes a symbol available for use by a subsequently loaded
-component.  It is unrelated to hal functions, which are described in
+component.  +
+It is unrelated to hal functions, which are described in
 hal_export_funct
 
-
+[NOTE]
+module params are persistant for the life of the module. +
+This does not cause problems with standard kernel modules, which are intended to
+be created and loaded once only. +
+When using instantiated components, a module param needs to be zeroed or nulled after
+the value is extracted by the component instance. +
+Otherwise, when the next instantiation of the component is created, that same value
+will be passed to it, unless explicitly set in the invocation.
 
 == Interpretation of license strings
 
-**MODULE_LICENSE** follows the kernel's definition of license strings.  Notably,
-"GPL" indicates "GNU Public License v2 __or later__".  (emphasis ours).
+**MODULE_LICENSE** follows the kernel's definition of license strings.  +
+Notably, "GPL" indicates "GNU Public License v2 __or later__".  (emphasis ours).
 
-.IP **"GPL"**
-GNU Public License v2 or later
-.IP **"GPL\ v2"**
-GNU Public License v2
-.IP **"GPL\ and\ additional\ rights"**
-GNU Public License v2 rights and more
-.IP **"Dual\ BSD/GPL"**
-GNU Public License v2 or BSD license choice
-.IP **"Dual\ MIT/GPL"**
-GNU Public License v2 or MIT license choice
-.IP **"Dual\ MPL/GPL"**
-GNU Public License v2 or Mozilla license choice
-.IP **"Proprietary"**
-Non-free products
-.P
 It is still good practice to include a license block which indicates the author,
 copyright date, and disclaimer of warranty as recommended by the GNU GPL.
 
-
+(Yes, __license__ should be spelt __licence__. Blame the US 'dumb down' of English grammar)
 
 == REALTIME CONSIDERATIONS
 Not available in userspace code.

--- a/docs/man/man3/rtapi_mutex.asciidoc
+++ b/docs/man/man3/rtapi_mutex.asciidoc
@@ -10,34 +10,37 @@
 
 == NAME
 
-rtapi_mutex -- Mutex-related functions
+**rtapi_mutex** -- Mutex-related functions
 
 
 
 == SYNTAX
- int rtapi_mutex_try(unsigned long *__mutex__)
 
- void rtapi_mutex_get(unsigned long *__mutex__)
+**int rtapi_mutex_try** ( **unsigned long** *__mutex__ )
 
- void rtapi_mutex_give(unsigned long *__mutex__)
+**void rtapi_mutex_get** ( **unsigned long** *__mutex__ )
+
+**void rtapi_mutex_give** ( **unsigned long** *__mutex__ )
 
 
 
 == ARGUMENTS
-.IP __mutex__
+__mutex__ +
 A pointer to the mutex.
 
 
 
 == DESCRIPTION
-**rtapi_mutex_try** makes a non-blocking attempt to get the mutex.
-If the mutex is available, it returns 0, and the mutex is no longer available.
+**rtapi_mutex_try** +
+makes a non-blocking attempt to get the mutex. +
+If the mutex is available, it returns 0, and the mutex is no longer available. +
 Otherwise, it returns a nonzero value.
 
-**rtapi_mutex_get** blocks until the mutex is available.
+**rtapi_mutex_get** +
+blocks until the mutex is available.
 
-**rtapi_mutex_give** releases a mutex acquired by **rtapi_mutex_try** or
-**rtapi_mutex_get**.
+**rtapi_mutex_give** +
+releases a mutex acquired by **rtapi_mutex_try** or **rtapi_mutex_get**.
 
 
 
@@ -53,4 +56,4 @@ init/cleanup, and realtime code.
 **rtapi_mutex_try** returns 0 for if the mutex was claimed, and nonzero
 otherwise.
 
-**rtapi_mutex_get** and **rtapi_mutex_gif** have no return value.
+**rtapi_mutex_get** and **rtapi_mutex_give** have no return value.

--- a/docs/man/man3/rtapi_outb.asciidoc
+++ b/docs/man/man3/rtapi_outb.asciidoc
@@ -10,27 +10,30 @@
 
 == NAME
 
-rtapi_outb, rtapi_inb -- Perform hardware I/O
+**rtapi_outb**, **rtapi_inb** -- Perform hardware I/O
 
 
 
 == SYNTAX
-void rtapi_outb(unsigned char __byte__, unsigned int __port__)
-unsigned char rtapi_inb(unsigned int __port__)
+**void rtapi_outb** ( **unsigned char** __byte__, **unsigned int** __port__ )
+
+**unsigned char rtapi_inb** ( **unsigned int** __port__ )
 
 
 
 == ARGUMENTS
-.IP __port__
+__port__ +
 The address of the I/O port
-.IP __byte__
+
+__byte__ +
 The byte to be written to the port
 
 
 
 == DESCRIPTION
-**rtapi_outb** writes a byte to a hardware I/O port.  **rtapi_inb**
-reads a byte from a hardware I/O port.
+**rtapi_outb** writes a byte to a hardware I/O port.  
+
+**rtapi_inb** reads a byte from a hardware I/O port.
 
 
 
@@ -47,7 +50,8 @@ Not available in userspace components.
 
 == NOTES
 The I/O address should be within a region previously allocated by
-**rtapi_request_region**.  Otherwise, another real-time module or the Linux
+**rtapi_request_region**.  +
+Otherwise, another real-time module or the Linux
 kernel might attempt to access the I/O region at the same time.
 
 

--- a/docs/man/man3/rtapi_print.asciidoc
+++ b/docs/man/man3/rtapi_print.asciidoc
@@ -10,32 +10,33 @@
 
 == NAME
 
-rtapi_print, rtapi_print_msg -- print diagnostic messages
+**rtapi_print**, **rtapi_print_msg** -- print diagnostic messages
 
 
 
 == SYNTAX
- void rtapi_print(const char *__fmt__, __...__)
+**void rtapi_print** ( **const char** *__fmt__, __...__ )
 
- void rtapi_print_msg(int level, const char *__fmt__, __...__)
+**void rtapi_print_msg** ( **int** __level__, **const char** *__fmt__, __...__ )
 
- typedef void(***rtapi_msg_handler_t**)(msg_level_t __level__, const char *__msg__);
- void **rtapi_set_msg_handler**(rtapi_msg_handler_t __handler__);
- rtapi_msg_handler_t **rtapi_set_msg_handler**(void);
+**typedef void**(***rtapi_msg_handler_t**)( **msg_level_t** __level__, **const char** *__msg__ );
+
+**void rtapi_set_msg_handler** ( **rtapi_msg_handler_t** __handler__ );
+
+**rtapi_msg_handler_t rtapi_set_msg_handler**(__void__);
 
 
 == ARGUMENTS
-.IP __level__
-A message level: One of **RTAPI_MSG_ERR**,
-**RTAPI_MSG_WARN**, **RTAPI_MSG_INFO**, or **RTAPI_MSG_DBG**.
+__level__ +
+A message level: +
+One of **RTAPI_MSG_ERR**, **RTAPI_MSG_WARN**, **RTAPI_MSG_INFO**, or **RTAPI_MSG_DBG**.
 
-.IP __handler__
+__handler__ +
 A function to call from **rtapi_print** or **rtapi_print_msg** to
 actually output the message.
 
-.IP __fmt
-__.IP __...
-__Other arguments are as for __printf__.
+__fmt__ __...__ +
+Other arguments are as for __printf__.
 
 
 
@@ -45,10 +46,13 @@ printf functions, except that a reduced set of formatting operations are
 supported.
 
 Depending on the RTOS, the default may be to print the message to stdout,
-stderr, a kernel log, etc.   In RTAPI code, the action may be changed by
-a call to **rtapi_set_msg_handler**.  A **NULL** argument to
+stderr, a kernel log, etc.   +
+In RTAPI code, the action may be changed by
+a call to **rtapi_set_msg_handler**.  +
+A **NULL** argument to
 **rtapi_set_msg_handler** restores the default handler.
-**rtapi_msg_get_handler** returns the current handler.  When the
+**rtapi_msg_get_handler** returns the current handler.  +
+When the
 message came from **rtapi_print**, __level__ is RTAPI_MSG_ALL.
 
 **rtapi_print_msg** works like rtapi_print but only prints if
@@ -58,9 +62,10 @@ __level__ is less than or equal to the current message level.
 
 == REALTIME CONSIDERATIONS
 **rtapi_print** and **rtapi_print_msg** May be called from user,
-init/cleanup, and realtime code.  **rtapi_get_msg_handler** and
-**ftapi_set_msg_handler** may be called from realtime init/cleanup
-code.  A message handler passed to **rtapi_set_msg_handler** may only
+init/cleanup, and realtime code.  +
+**rtapi_get_msg_handler** and **rtapi_set_msg_handler** may be called from realtime init/cleanup
+code.  +
+A message handler passed to **rtapi_set_msg_handler** may only
 call functions that can be called from realtime code.
 
 
@@ -71,5 +76,6 @@ None.
 
 
 == SEE ALSO
-**rtapi_set_msg_level**, **rtapi_get_msg_level**,
+**rtapi_set_msg_level** +
+**rtapi_get_msg_level** +
 **printf**

--- a/docs/man/man3/rtapi_prio.asciidoc
+++ b/docs/man/man3/rtapi_prio.asciidoc
@@ -10,43 +10,50 @@
 
 == NAME
 
-rtapi_prio -- thread priority functions
+**rtapi_prio** -- thread priority functions
 
 
 
 == SYNTAX
-int rtapi_prio_highest()
-int rtapi_prio_lowest()
-int rtapi_prio_next_higher(int __prio__)
-int rtapi_prio_next_lower(int __prio__)
+**int rtapi_prio_highest**()
+
+**int rtapi_prio_lowest**()
+
+**int rtapi_prio_next_higher** ( **int** __prio__ )
+
+**int rtapi_prio_next_lower** ( **int** __prio__)
 
 
 
 == ARGUMENTS
-.IP __prio__
+__prio__ +
 A value returned by a prior **rtapi_prio_xxx** call
 
 
 
 == DESCRIPTION
 The **rtapi_prio_xxxx** functions provide a portable way to set task
-priority.  The mapping of actual priority to priority number depends on the
-RTOS.  Priorities range from **rtapi_prio_lowest** to
-**rtapi_prio_highest**, inclusive. To use this API, use one of two methods:
+priority.  +
+The mapping of actual priority to priority number depends on the
+RTOS.  +
+Priorities range from **rtapi_prio_lowest** to
+**rtapi_prio_highest**, inclusive. +
+To use this API, use one of two methods:
 
-.IP 1)
+__1)__ +
 Set your lowest priority task to **rtapi_prio_lowest**, and for
 each task of the next lowest priority, set their priorities to
 **rtapi_prio_next_higher(previous)**.
 
-.IP 2)
+__2)__ +
 Set your highest priority task to **rtapi_prio_highest**, and
 for each task of the next highest priority, set their priorities
 to **rtapi_prio_next_lower(previous)**.
 
-.PP
-N.B. A high priority task will pre-empt or interrupt a lower priority
-task. Linux is always the lowest priority!
+[NOTE]
+A high priority task will pre-empt or interrupt a lower priority
+task. +
+Linux is always the lowest priority!
 
 
 

--- a/docs/man/man3/rtapi_region.asciidoc
+++ b/docs/man/man3/rtapi_region.asciidoc
@@ -10,25 +10,25 @@
 
 == NAME
 
-rtapi_region -- functions to manage I/O memory regions
+**rtapi_region** -- functions to manage I/O memory regions
 
 
 
 == SYNTAX
- void *rtapi_request_region(unsigned long __base__, unsigned long int __size__, const char *__name__)
+**void * rtapi_request_region** ( **unsigned long** __base__, **unsigned long int** __size__, **const char** *__name__ )
 
- void rtapi_release_region(unsigned long __base__, unsigned long int __size__)
+**void rtapi_release_region** ( **unsigned long** __base__, **unsigned long int** __size__ )
 
 
 
 == ARGUMENTS
-.IP __base__
+__base__ +
 The base address of the I/O region
 
-.IP __size__
+__size__ +
 The size of the I/O region
 
-.IP __name__
+__name__ +
 The name to be shown in /proc/ioports
 
 

--- a/docs/man/man3/rtapi_set_msg_level.asciidoc
+++ b/docs/man/man3/rtapi_set_msg_level.asciidoc
@@ -10,25 +10,26 @@
 
 == NAME
 
-rtapi_get_msg_level, rtapi_set_msg_level -- Get or set the logging level
+**rtapi_get_msg_level**, **rtapi_set_msg_level** -- Get or set the logging level
 
 
 
 == SYNTAX
- int rtapi_set_msg_level(int __level__)
+**int rtapi_set_msg_level** ( **int** __level__ )
 
- int rtapi_get_msg_level()
+**int rtapi_get_msg_level**()
 
 
 
 == ARGUMENTS
-.IP __level__
+__level__ +
 The desired logging level
 
 
 
 == DESCRIPTION
-Get or set the RTAPI message level used by **rtapi_print_msg**.  Depending
+Get or set the RTAPI message level used by **rtapi_print_msg**.  +
+Depending
 on the RTOS, this level may apply to a single RTAPI module, or it may apply
 to a group of modules.
 

--- a/docs/man/man3/rtapi_shmem.asciidoc
+++ b/docs/man/man3/rtapi_shmem.asciidoc
@@ -10,55 +10,67 @@
 
 == NAME
 
-rtapi_shmem -- Functions for managing shared memory blocks
+**rtapi_shmem** -- Functions for managing shared memory blocks
 
 
 
 == SYNTAX
- int rtapi_shmem_new(int __key__, int __module_id__, unsigned long int __size__)
+**int rtapi_shmem_new** ( **int** __key__, **int** __module_id__, **unsigned long int** __size__ )
 
- int rtapi_shmem_delete(int __shmem_id__, int __module_id__)
+**int rtapi_shmem_delete** ( **int** __shmem_id__, **int** __module_id__ )
 
- int rtapi_shmem_getptr(int __shmem_id__, void ** __ptr__, unsigned long int * __sizeptr__)
+**int rtapi_shmem_getptr(**int** __shmem_id__, **void** ** __ptr__, **unsigned long int** * __sizeptr__ )
 
- int rtapi_shmem_exists(int __key__)
+**int rtapi_shmem_exists** ( **int** __key__ )
 
 
 
 == ARGUMENTS
-.IP __key__**
-**Identifies the memory block.  Key must be nonzero.  All modules wishing to use the same memory must use the same key.
+__key__ +
+Identifies the memory block.  Key must be nonzero.  +
+All modules wishing to use the same memory must use the same key.
 
-.IP __module_id__**
-**Module identifier returned by a prior call to **rtapi_init**.
+__module_id__ +
+Module identifier returned by a prior call to **rtapi_init**.
 
-.IP __size__**
-**The desired size of the shared memory block, in bytes
+__size__ +
+The desired size of the shared memory block, in bytes
 
-.IP __ptr__**
-**The pointer to the shared memory block.  Note that the block may be mapped
+__ptr__ +
+The pointer to the shared memory block.  +
+Note that the block may be mapped
 at a different address for different modules.
 
-.IP __sizeptr__**
-**Pointer to an unsigned long, or 0. If non-zero, set to the size of the shared memory block.
+__sizeptr__ +
+Pointer to an unsigned long, or 0. +
+If non-zero, set to the size of the shared memory block.
 
 
 
 == DESCRIPTION
 
-**rtapi_shmem_new** allocates a block of shared memory.  __key__
-identifies the memory block, and must be non-zero.  All modules
+**rtapi_shmem_new** allocates a block of shared memory.  
+
+__key__ identifies the memory block, and must be non-zero.  +
+All modules
 wishing to access the same memory must use the same key.
+
 __module_id__ is the ID of the module that is making the call (see
-rtapi_init).  The block will be at least __size__ bytes, and may
-be rounded up.  Allocating many small blocks may be very wasteful.
+rtapi_init).  +
+The block will be at least __size__ bytes, and may
+be rounded up.  +
+Allocating many small blocks may be very wasteful.
 When a particular block is allocated for the first time, the first
-4 bytes are zeroed.  Subsequent allocations of the same block
+4 bytes are zeroed.  +
+Subsequent allocations of the same block
 by other modules or processes will not touch the contents of the
-block.  Applications can use those bytes to see if they need to 
+block.  +
+Applications can use those bytes to see if they need to 
 initialize the block, or if another module already did so.
+
 On success, it returns a positive integer ID, which is used for
-all subsequent calls dealing with the block.  On failure it 
+all subsequent calls dealing with the block.  +
+On failure it 
 returns a negative error code.
 
 Calling **rtapi_shmem_new** with a zero size argument will
@@ -66,14 +78,15 @@ attach to an existing shared memory segment; if this segment does not
 exist a negative error code is returned.
 
 **rtapi_shmem_delete** frees the shared memory block associated
-with __shmem_id__.  __module_id__ is the ID of the calling module.
+with __shmem_id__.  __module_id__ is the ID of the calling module. +
 Returns a status code.
 
 **rtapi_shmem_getptr** sets __*ptr__ to point to shared memory block
 associated with __shmem_id__.
 
 **rtapi_shmem_exists** may be used to test if a shared memory segment 
-exists. A value of 1 means the segment exists, a value of 0 means it doesnt.
+exists. +
+A value of 1 means the segment exists, a value of 0 means it doesnt.
 
 
 
@@ -84,8 +97,4 @@ or realtime tasks.
 
 **rtapi_shmem_new** and **rtapi_shmem_dete** may not be called from
 realtime tasks.
-
-
-
-== RETURN VALUE
 

--- a/docs/man/man3/rtapi_snprintf.asciidoc
+++ b/docs/man/man3/rtapi_snprintf.asciidoc
@@ -10,15 +10,15 @@
 
 == NAME
 
-rtapi_snprintf, rtapi_vsnprintf -- Perform snprintf-like string formatting
+**rtapi_snprintf**, **rtapi_vsnprintf** -- Perform snprintf-like string formatting
 
 
 
 == SYNTAX
- int rtapi_snprintf(char *__buf__, unsigned long int __size__, const char *__fmt__, __...__)
+**int rtapi_snprintf** ( **char** *__buf__, **unsigned long int** __size__, **const char** *__fmt__, __...__)
 
- int rtapi_vsnprintf(char *__buf__, unsigned long int __size__, const char *__fmt__, va_list __apfB)
-__
+**int rtapi_vsnprintf** ( **char** *__buf__, **unsigned long int** __size__, **const char** *__fmt__, **va_list** __apfB__)
+
 
 
 == ARGUMENTS
@@ -30,7 +30,8 @@ As for __snprintf__ or __vsnprintf__.
 These functions work like the standard C printf functions, except that a
 reduced set of formatting operations are supported.
 
-In particular: formatting of long long values is not supported.  Formatting of
+In particular: formatting of long long values is not supported.  +
+Formatting of
 floating-point values is done as though with %A even when other formats like %f
 are specified.
 

--- a/docs/man/man3/rtapi_task_new.asciidoc
+++ b/docs/man/man3/rtapi_task_new.asciidoc
@@ -10,40 +10,47 @@
 
 == NAME
 
-rtapi_task_new -- create a realtime task
+**rtapi_task_new** -- create a realtime task
 
 
 
 == SYNTAX
-int rtapi_task_new(void (*__taskcode__)(void*), void *__arg__,
-	int __prio__, unsigned long __stacksize__, int
-	__uses_fp__, char **__name__, int __cpu_id__)
-int rtapi_task_delete(int __task_id__)
+**int rtapi_task_new** (**void**  (* __taskcode__)(**void** * ), **void** * __arg__, **int** __prio__, **unsigned long** __stacksize__, **int** __uses_fp__, **char** **__name__, **int** __cpu_id__ )
+
+**int rtapi_task_delete** ( **int**  __task_id__ )
 
 
 == ARGUMENTS
-.IP __taskcode__
+__taskcode__ +
 A pointer to the function to be called when the task is started
-.IP __arg__
-An argument to be passed to the __taskcode__ function when the task is
-started
-.IP __prio__
+
+__arg__ +
+An argument to be passed to the __taskcode__ function when the task is started
+
+__prio__ +
 A task priority value returned by **rtapi_prio_xxxx**
-.IP __uses_fp__
+
+__uses_fp__ +
 A flag that tells the OS whether the task uses floating point or not.
-.IP __task_id__
+
+__task_id__ +
 A task ID returned by a previous call to **rtapi_task_new**
-.IP __name__
+
+__name__ +
 The name argument is used to identify the thread by name at the
-operating system level. Corresponds to the HAL name of the thread.
-.IP __cpu_id__
+operating system level. +
+Corresponds to the HAL name of the thread.
+
+__cpu_id__ +
 Bind this thread to a particular CPU core.
 
 
 
 == DESCRIPTION
-**rtapi_task_new** creates but does not start a realtime task.  The task is
-created in the "paused" state.  To start it, call either **rtapi_task_start**
+**rtapi_task_new** creates but does not start a realtime task.  +
+The task is
+created in the "paused" state.  +
+To start it, call either **rtapi_task_start**
 for periodic tasks, or **rtapi_task_resume** for free-running tasks.
 
 
@@ -54,12 +61,16 @@ Call only from within init/cleanup code, not from realtime tasks.
 
 
 == RETURN VALUE
-On success, returns a positive integer task ID.  This ID is used
-for all subsequent calls that need to act on the task.  On failure,
+On success, returns a positive integer task ID.  +
+This ID is used
+for all subsequent calls that need to act on the task.  +
+On failure,
 returns an RTAPI status code.
 
 
 
 == SEE ALSO
-**rtapi_prio**, **rtapi_task_start**, **rtapi_task_wait**, **rtapi_task_resume
-**
+**rtapi_prio** +
+**rtapi_task_start** +
+**rtapi_task_wait** +
+**rtapi_task_resume**

--- a/docs/man/man3/rtapi_task_pause.asciidoc
+++ b/docs/man/man3/rtapi_task_pause.asciidoc
@@ -10,18 +10,19 @@
 
 == NAME
 
-rtapi_task_pause, rtapi_task_resume -- pause and resume real-time tasks
+**rtapi_task_pause**, **rtapi_task_resume** -- pause and resume real-time tasks
 
 
 
 == SYNTAX
-void rtapi_task_pause(int __task_id__)
-void rtapi_task_resume(int __task_id__)
+**void rtapi_task_pause** ( **int** __task_id__ )
+
+**void rtapi_task_resume** ( **int** __task_id__)
 
 
 
 == ARGUMENTS
-.IP __task_id__
+__task_id__ +
 An RTAPI task identifier returned by an earlier call to **rtapi_task_new**.
 
 
@@ -29,26 +30,28 @@ An RTAPI task identifier returned by an earlier call to **rtapi_task_new**.
 **rtapi_task_resume** starts a task in free-running mode. 
 The task must be in the "paused" state.
 
-A free running task runs continuously until either:
-.IP 1)
-It is prempted by a higher priority task.  It will resume as soon as the higher
+A free running task runs continuously until either: +
+__1)__ +
+It is prempted by a higher priority task.  +
+It will resume as soon as the higher
 priority task releases the CPU.
-.IP 2)
-It calls a blocking function, like **rtapi_sem_take**.  It will resume when
-the function unblocks.
-.IP 3)
-It is returned to the "paused" state by **rtapi_task_pause**.  May be called
-from init/cleanup code, and from within realtime tasks.
 
+__2)__ +
+It calls a blocking function, like **rtapi_sem_take**.  +
+It will resume when the function unblocks.
+
+__3)__ + 
+It is returned to the "paused" state by **rtapi_task_pause**.  +
+May be called from init/cleanup code, and from within realtime tasks.
 
 
 **rtapi_task_pause** causes a task to stop execution and change
-to the "paused" state.  The task can be free-running or periodic.
+to the "paused" state.  +
+The task can be free-running or periodic. +
 Note that **rtapi_task_pause** may called from any task, or from init
-or cleanup code, not just from the task that is to be paused.
+or cleanup code, not just from the task that is to be paused. +
 The task will resume execution when either **rtapi_task_resume** or
 **rtapi_task_start** (depending on whether this is a free-running or periodic task) is called.
-
 
 
 
@@ -63,4 +66,5 @@ An RTAPI status code.
 
 
 == SEE ALSO
-**rtapi_task_new**, **rtapi_task_start**
+**rtapi_task_new** +
+**rtapi_task_start**

--- a/docs/man/man3/rtapi_task_start.asciidoc
+++ b/docs/man/man3/rtapi_task_start.asciidoc
@@ -10,24 +10,25 @@
 
 == NAME
 
-rtapi_task_start -- start a realtime task in periodic mode
+**rtapi_task_start** -- start a realtime task in periodic mode
 
 
 
 == SYNTAX
-int rtapi_task_start(int __task_id__, unsigned long __period_nsec__)
+**int rtapi_task_start** ( **int** __task_id__, **unsigned long** __period_nsec__ )
 
 
 == ARGUMENTS
-.IP __task_id__
+__task_id__ +
 A task ID returned by a previous call to **rtapi_task_new**
-.IP __period_nsec__
+
+__period_nsec__ +
 The clock period in nanoseconds between iterations of a periodic task
 
 
 == DESCRIPTION
-**rtapi_task_start** starts a task in periodic mode.  The task must be in the
-__paused__ state.
+**rtapi_task_start** starts a task in periodic mode.  +
+The task must be in the __paused__ state.
 
 
 
@@ -42,5 +43,6 @@ Returns an RTAPI status code.
 
 
 == SEE ALSO
-**rtapi_task_new**, **rtapi_task_pause**, **rtapi_task_resume
-**
+**rtapi_task_new** +
+**rtapi_task_pause** +
+**rtapi_task_resume**

--- a/docs/man/man3/rtapi_task_wait.asciidoc
+++ b/docs/man/man3/rtapi_task_wait.asciidoc
@@ -10,18 +10,19 @@
 
 == NAME
 
-rtapi_task_wait -- suspend execution of this periodic task
+**rtapi_task_wait** -- suspend execution of this periodic task
 
 
 
 == SYNTAX
-void rtapi_task_wait()
+**void rtapi_task_wait**()
 
 
 
 == DESCRIPTION
 **rtapi_task_wait** suspends execution of the current task until the next
-period.  The task must be periodic.  If not, the result is undefined.
+period.  +
+The task must be periodic.  If not, the result is undefined.
 
 
 
@@ -36,4 +37,5 @@ None
 
 
 == SEE ALSO
-**rtapi_task_start**, **rtapi_task_pause**
+**rtapi_task_start** +
+**rtapi_task_pause**


### PR DESCRIPTION
Several corrections to obvious errors, but probably wrong elsewhere too

Thats it, I am finished with manual pages!

Signed-off-by: Mick <arceye@mgware.co.uk>