### PR TITLE
Add note to stepconf and pncconf docs advising sim run first.

### DIFF
--- a/docs/config/pncconf.asciidoc
+++ b/docs/config/pncconf.asciidoc
@@ -37,6 +37,12 @@ is also a help button that gives some help information about the pages, diagrams
 TIP: PNCconf's help page should have the most up to date info and has additional
  details.
 
+[NOTE]
+Before starting pncconf it is advisable to first run one of the simulated configs,
+eg. axis_mm.  This will ensure your system is working properly and will create
+a machinekit folder in your home dir if it does not already exist.
+This is required for pncconf.
+
 [float]
 Step by Step Instructions
 //__=========================

--- a/docs/config/stepconf.asciidoc
+++ b/docs/config/stepconf.asciidoc
@@ -27,6 +27,13 @@ The file extension is .stepconf.
 
 The Stepconf Wizard works best with at least 800 x 600 screen resolution.
 
+[NOTE]
+Before starting stepconf it is advisable to first run one of the simulated configs,
+eg. axis_mm.  This will ensure your system is working properly and will create
+a machinekit folder in your home dir if it does not already exist.
+This is required for stepconf.
+
+
 [float]
 Step by Step Instructions
 //__=========================


### PR DESCRIPTION
Required to test system is properly installed but also to
ensure there has been one running of the linuxcnc
script before stepconf/pncconf is run, to ensure the `~/machinekit`
path is valid

Signed-off-by: Mick <arceye@mgware.co.uk>