### PR TITLE
Remove references to installing separate machinekit-dev package.

### DIFF
--- a/docs/code/Contributing-to-Machinekit.asciidoc
+++ b/docs/code/Contributing-to-Machinekit.asciidoc
@@ -169,7 +169,7 @@ There's an automatic way to check a branch for each commit being buildable
 Use as follows (in this case testing every commit from origin/master to
 HEAD, including running regression tests):
 
-`cd machinekit-dev`
+`cd machinekit`
 
 `git-test-sequence origin/master..  '(cd src;make;runtests)'`
 

--- a/docs/getting-started/install-runtime-packages.asciidoc
+++ b/docs/getting-started/install-runtime-packages.asciidoc
@@ -11,15 +11,15 @@ kernels and flavors possible) Choose the same one as the kernel you use:
 
 [source,bash]
 ----
-sudo apt-get install machinekit-rt-preempt machinekit-dev
+sudo apt-get install machinekit-rt-preempt
 ----
 [source,bash]
 ----
-sudo apt-get install machinekit-xenomai machinekit-dev
+sudo apt-get install machinekit-xenomai
 ----
 [source,bash]
 ----
-sudo apt-get install machinekit-posix  machinekit-dev # non-RT (aka 'simulator mode')
+sudo apt-get install machinekit-posix # non-RT (aka 'simulator mode')
 ----
 
 This package will provide local copies of the manual pages and a man page stub to remind

--- a/docs/hal/comp.asciidoc
+++ b/docs/hal/comp.asciidoc
@@ -38,19 +38,9 @@ old = tmp;
 
 == Installing
 
-If you're working with an installed version of Machinekit you will need to install
-the development packages.
+If you're working with an installed version of Machinekit you no longer need to install
+the development packages. They are part of the main machinekit-{kernel-flavour} package
 
-One method is to say following line in a terminal.
-
-.Installing Dev
-[source, bash]
-----
-sudo apt-get install machinekit-dev
-----
-
-Another method is to use the Synaptic Package Manager from the main Debian menu
-to install machinekit-dev.
 
 == Definitions
 


### PR DESCRIPTION
This was deprecated in PR #1230

Signed-off-by: Mick <arceye@mgware.co.uk>