### PR TITLE
Enable Google Analytics

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -63,6 +63,4 @@ exclude: [Makefile,
 	 '*/*.9' ]
 
 # for www.machinekit.io
-google_analytics:  UA-48383649-1
-
-
+google_analytics_id:  UA-108874248-1

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -7,6 +7,5 @@
   {{ content }}
   </div>
   {% include footer.html %}
-  {% include analytics.html %}
 </body>
 </html>


### PR DESCRIPTION
GA has been added previously but was not active to a typo in the Jekyll configuration.