### PR TITLE
Interim clarification on BBB SD card images

### DIFF
--- a/docs/getting-started/machinekit-images.asciidoc
+++ b/docs/getting-started/machinekit-images.asciidoc
@@ -8,9 +8,25 @@
 Robert C. Nelson kindly provides a 2-weekly build of a complete Debian with
 Machinekit image for a BeagleBone Black/White.
 
+
 Head over to link:http://elinux.org/Beagleboard:BeagleBoneBlack_Debian#BBW.2FBBB_.28All_Revs.29_Machinekit[elinux.org/Beagleboard:BeagleBoneBlack_Debian#BBW.2FBBB_.28All_Revs.29_Machinekit]
-and download and install the image on a microSD card and run the image from
-that, or install the image on the eMMC.
+and download and install the image on a microSD card and run the image from that, or install the image on the eMMC.
+
+**Important:**
+
+The 3.8 kernel version image is recommended as a starting point. +
+_bone-debian-8.7-machinekit-armhf-2017-02-12-4gb.img.xz_
+
+This uses a xenomai kernel and is pretty much guaranteed to work without any adjustment of configs etc.
+
+There are later rt-preempt 4.x.x kerneled versions of the image available on the same site. +
+These will require some familiarity with the BBB boot process and the configs to use sucessfully.
+
+For kernels after 3.8 you may need to change the device tree overlay in /boot/uEnv.txt. +
+https://elinux.org/Beagleboard:BeagleBoneBlack_Debian#Loading_custom_capes has some help on this matter.
+
+Read the posts on the forum covering these images and when they make sense to you, you are probably ready to try the later images :) +
+https://groups.google.com/forum/#!forum/machinekit
 
 Instructions on writing a microSD card link:https://encrypted.google.com/search?q=beaglebone+black+flashing+SD+card[can be found here] by doing a Google search. There are plenty examples and tutorials
 around also for writing the image to the eMMC.


### PR DESCRIPTION
Steer beginners to the 3.8 kernel image until they can grasp the issues
involved in using a later image.

(Or until someone produces a simple guide to using them)

Signed-off-by: Mick <arceye@mgware.co.uk>