### PR TITLE
Fix broken Google Custom Search Engine

### DIFF
--- a/_includes/search-bar.html
+++ b/_includes/search-bar.html
@@ -1,16 +1,22 @@
+<script>
+  (function() {
+    var cx = '013132401186084955638:hpvljajpulu';
+    var gcse = document.createElement('script');
+    gcse.type = 'text/javascript';
+    gcse.async = true;
+    gcse.src = 'https://cse.google.com/cse.js?cx=' + cx;
+    var s = document.getElementsByTagName('script')[0];
+    s.parentNode.insertBefore(gcse, s);
+  })();
+
+</script>
+
 <search-bar>
   <div class="grid">
     <div class="unit align-left center-on-mobiles">
       <p>
         <div class="top-search">
-        <form method="get" id="searchform" id="searchbox_013132401186084955638:hpvljajpulu" action="http://machinekit.io/search-result.html">
-        <div>
-        <input value="013132401186084955638:hpvljajpulu" name="cx" type="hidden"/>
-        <input value="FORID:11" name="cof" type="hidden"/>
-        Search:<BR>
-        <input type="text" value="" name="s" id="s" onfocus="defaultInput(this)" onblur="clearInput(this)" />
-        </div>
-        </form>
+	<gcse:searchbox-only></gcse:searchbox-only>
         </div>
       </p>
     </div>


### PR DESCRIPTION
Google have moved to v2 of their CSE which of course is
completely incompatible with our present v1, so currently
searches don't work.

This just inserts a default GCSE search box, which works and
renders a new page with results.

When time allows will revisit and try to make it prettier:)

Signed-off-by: Mick <arceye@mgware.co.uk>