### PR TITLE
Add Forum link to ensure display same in different browsers

### DIFF
--- a/_includes/primary-nav-items2.html
+++ b/_includes/primary-nav-items2.html
@@ -23,6 +23,9 @@
   <li>
     <a href="{{ site.repository }}">GitHub</a>
   </li>
+  <li">
+    <a href="https://groups.google.com/forum/#!forum/machinekit">Forum</a>
+  </li>
   <li>
     {% include search-bar.html %}
   </li>


### PR DESCRIPTION
Rendering was different in Opera, so presumably Chrome, Vivaldi and any other Chrome based browser
This fills the top line so they have both search boxes in second line, as Firefox did anyway