### PR TITLE
Clarify the availability of Xenomai packages and kernels in the repo

### DIFF
--- a/docs/getting-started/install-rt-kernel-amd64.asciidoc
+++ b/docs/getting-started/install-rt-kernel-amd64.asciidoc
@@ -12,6 +12,10 @@ install your kernel:
 sudo apt-get install linux-image-xenomai.x86-amd64 	  # amd64
 ----
 
+[NOTE]
+There are only Xenomai kernels for Wheezy and Jessie not Stretch
+
+
 = RT-PREEMPT realtime kernel (amd64)
 
 == Debian Wheezy has an older RT-PREEMPT kernel.

--- a/docs/getting-started/install-rt-kernel-i386.asciidoc
+++ b/docs/getting-started/install-rt-kernel-i386.asciidoc
@@ -12,6 +12,9 @@ Choose and copy and paste the following into a shell to install your kernel:
 sudo apt-get install linux-image-xenomai.x86-686-pae      # i386
 ----
 
+[NOTE]
+There are only Xenomai kernels for Wheezy and Jessie not Stretch
+
 = RT-PREEMPT realtime kernel (i386)
 
 == Debian Wheezy has an older RT-PREEMPT kernel 

--- a/docs/getting-started/install-runtime-packages.asciidoc
+++ b/docs/getting-started/install-runtime-packages.asciidoc
@@ -17,6 +17,10 @@ sudo apt-get install machinekit-rt-preempt
 ----
 sudo apt-get install machinekit-xenomai
 ----
+
+[NOTE]
+There are only Xenomai packages for Wheezy and Jessie not Stretch
+
 [source,bash]
 ----
 sudo apt-get install machinekit-posix # non-RT (aka 'simulator mode')


### PR DESCRIPTION
Specifically that Stretch does not provide packages or kernels for Xenomai

Signed-off-by: Mick <arceye@mgware.co.uk>