### PR TITLE
Pause google analytics usage until its compliance with GDPR is verified.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -63,4 +63,4 @@ exclude: [Makefile,
 	 '*/*.9' ]
 
 # for www.machinekit.io
-google_analytics_id:  UA-108874248-1
+#google_analytics_id:  UA-108874248-1

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -7,7 +7,7 @@
   <meta name="generator" content="Jekyll v{{ jekyll.version }}">
   <!--  <link rel="alternate" type="application/rss+xml" title="Jekyll • Simple, blog-aware, static sites - Feed" href="/feed.xml"> -->
 
-  {% include analytics.html %}
+  <!--  {% include analytics.html %} -->
   {% include livereload.html %}
 
   <link rel="alternate" type="application/atom+xml" title="Recent commits to Machinekit's master branch" href="{{ site.repository }}/commits/master.atom">


### PR DESCRIPTION
If you use google analytics, despite in effect giving them all your
site traffic data for free, in return for a rehashed view of it,
you are counted as the 'data controller'.

Even the retention of accessing IP addresses is regarded
as personal information.

Safest thing for now is to suspend use until assessed as compliant,
or consider discontinuance if of no practical benefit.

Signed-off-by: Mick <arceye@mgware.co.uk>