### PR TITLE
Get rid of google CSE and do search that works.

### DIFF
--- a/_includes/forum-search.html
+++ b/_includes/forum-search.html
@@ -1,10 +1,12 @@
 <script type="text/javascript">
     function goToPage() {
         var page = document.getElementById("uniqA45DE").value;
-	var base = "https://www.google.co.uk/search?&q=site%3Agroups.google.com%2Fd%2Fmsg%2Fmachinekit%2F%20";
-	var full = base + page;
-        window.open(full);
-	
+	var base1 = "https://www.google.co.uk/search?&q=site%3Agroups.google.com%2Fd%2Fmsg%2Fmachinekit%2F%20";
+	var base2 = "https://www.google.co.uk/search?&q=site%3Amachinekit.io%2Fdocs%2F%20";
+	var full = base1 + page;
+	var full2 = base2 + page;
+	window.open(full);
+	window.open(full2);
     }
 </script>
 
@@ -14,7 +16,7 @@
         <div class="forum-search">
 	<p>
         <form>
-	    <input type="text" placeholder="Search Forum..." name="uniqA45DE" size="10" id="uniqA45DE" onkeypress="if (event.keyCode == 13) { goToPage(); return false;}" />
+	    <input type="text" placeholder="Search ..." name="uniqA45DE" size="10" id="uniqA45DE" onkeypress="if (event.keyCode == 13) { goToPage(); return false;}" />
         </form>
         </p>
 	</div>

--- a/_includes/primary-nav-items.html
+++ b/_includes/primary-nav-items.html
@@ -24,7 +24,7 @@
     <a href="{{ site.repository }}">GitHub</a>
   </li>
   <li>
-    {% include search-bar.html %}
+    {% include document-search.html %}
   </li>
   <li>
     {% include commercial-support.html %}

--- a/_includes/primary-nav-items.html
+++ b/_includes/primary-nav-items.html
@@ -24,9 +24,6 @@
     <a href="{{ site.repository }}">GitHub</a>
   </li>
   <li>
-    {% include document-search.html %}
-  </li>
-  <li>
     {% include commercial-support.html %}
   </li>
   <li>

--- a/_includes/primary-nav-items2.html
+++ b/_includes/primary-nav-items2.html
@@ -27,7 +27,7 @@
     <a href="https://groups.google.com/forum/#!forum/machinekit">Forum</a>
   </li>
   <li>
-    {% include search-bar.html %}
+    {% include document-search.html %}
   </li>
   <li>
     {% include forum-search.html %}

--- a/_includes/primary-nav-items2.html
+++ b/_includes/primary-nav-items2.html
@@ -27,9 +27,6 @@
     <a href="https://groups.google.com/forum/#!forum/machinekit">Forum</a>
   </li>
   <li>
-    {% include document-search.html %}
-  </li>
-  <li>
     {% include forum-search.html %}
   </li>  
   <li>

--- a/_includes/search-bar.html
+++ b/_includes/search-bar.html
@@ -4,7 +4,7 @@
         var gcse = document.createElement('script');
         gcse.type = 'text/javascript';
         gcse.async = true;
-        gcse.src = (document.location.protocol == 'https:' ? 'https:' : 'http:') + '//www.google.com/cse/cse.js?cx=' + cx;
+        gcse.src = 'https://www.google.com/cse.js?cx=' + cx;
         var s = document.getElementsByTagName('script')[0];
         s.parentNode.insertBefore(gcse, s);
     })();


### PR DESCRIPTION
Google has seamlessly removed a directory level from the path to their search engine,
rendering our searches that use it useless.

Hopefully will restore.

Signed-off-by: Mick <arceye@mgware.co.uk>