### PR TITLE
Use new format for setting of ENV variables

### DIFF
--- a/.github/workflows/build-preview-pages.yaml
+++ b/.github/workflows/build-preview-pages.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: Create output directory
         run: |
           mkdir ./${{ env.OUTPUT_NAME }}
-          echo ::set-env name=OUTPUT_DIRECTORY::$(pwd)/${{ env.OUTPUT_NAME }}
+          echo "OUTPUT_DIRECTORY=$(pwd)/${{ env.OUTPUT_NAME }}" >> "$GITHUB_ENV"
           echo "The output directory is ${{ env.OUTPUT_DIRECTORY }}"
           mkdir ./${{ env.OUTPUT_NAME }}/build      
 

--- a/.github/workflows/ping-remote-repository.yaml
+++ b/.github/workflows/ping-remote-repository.yaml
@@ -19,8 +19,8 @@ jobs:
         str="${{ github.repository }}"
         IFS='/'
         read -ra ARRA <<< "$str"
-        echo ::set-env name=PARSED_USERNAME::${ARRA[0]}
-        echo ::set-env name=PARSED_LOCAL_REPOSITORY::${ARRA[1]}
+        echo "PARSED_USERNAME=${ARRA[0]}" >> "$GITHUB_ENV"
+        echo "PARSED_LOCAL_REPOSITORY=${ARRA[1]}" >> "$GITHUB_ENV"
 
       # Another shell is needed for the environment variables to take effect
     - name: Print parsed Github handle and repository
@@ -38,4 +38,4 @@ jobs:
         token: ${{ secrets.ROBOT_TOKEN }}
         repository: ${{ env.PARSED_USERNAME }}/machinekit.github.io
         event-type: rebuild-site-now
-        client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}", "authorization": "${{ secrets.DOCUMENTATION_PING_KEYCODE }}", "originating_repository": "${{ env.PARSED_USERNAME }}/${{ env.PARSED_LOCAL_REPOSITORY }}"}'
+        client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}", "originating_repository": "${{ env.PARSED_USERNAME }}/${{ env.PARSED_LOCAL_REPOSITORY }}"}'


### PR DESCRIPTION
This pull request solves issue #325.

GitHub [deprecated](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/) the old `set-env` command format for setting of environment variables. Instead, the new config files has to be used.

This is the second part of the solution, first is the pull request machinekit/machinekit.github.io#65 (which should be merged first before this PR).